### PR TITLE
Remove duplicated start of week

### DIFF
--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -241,25 +241,6 @@ const page = usePage<{
                 </select>
                 <InputError :message="form.errors.week_start" class="mt-2" />
             </div>
-            <div class="col-span-6 sm:col-span-4">
-                <InputLabel for="week_start" value="Start of the week" />
-                <select
-                    id="week_start"
-                    v-model="form.week_start"
-                    name="week_start"
-                    required
-                    class="mt-1 block w-full border-input-border bg-input-background text-text-primary focus:border-input-border-active rounded-md shadow-sm">
-                    <option value="" disabled>Select a week day</option>
-                    <option
-                        v-for="(weekdayTranslated, weekdayKey) in $page.props
-                            .weekdays"
-                        :key="weekdayKey"
-                        :value="weekdayKey">
-                        {{ weekdayTranslated }}
-                    </option>
-                </select>
-                <InputError :message="form.errors.week_start" class="mt-2" />
-            </div>
         </template>
 
         <template #actions>


### PR DESCRIPTION
I noticed a small UI issue in the form where the week_start select input is rendered twice. This PR removes a duplicated week_start select input from the form. Both instances are identical and appear one after another. While it's a minor issue, it results in two identical dropdowns being shown to the user, which can be confusing.

I understand the project is still in early development and not open to external contributions. I’m submitting this PR just to highlight the bug in case it helps with cleanup later. Please feel free to close or ignore if this isn’t helpful right now.