### PR TITLE
Extend description to 5000 chars, closes #914

### DIFF
--- a/app/Http/Requests/V1/TimeEntry/TimeEntryStoreRequest.php
+++ b/app/Http/Requests/V1/TimeEntry/TimeEntryStoreRequest.php
@@ -79,7 +79,7 @@ class TimeEntryStoreRequest extends BaseFormRequest
             'description' => [
                 'nullable',
                 'string',
-                'max:500',
+                'max:5000',
             ],
             // List of tag IDs
             'tags' => [

--- a/app/Http/Requests/V1/TimeEntry/TimeEntryUpdateMultipleRequest.php
+++ b/app/Http/Requests/V1/TimeEntry/TimeEntryUpdateMultipleRequest.php
@@ -79,7 +79,7 @@ class TimeEntryUpdateMultipleRequest extends BaseFormRequest
             'changes.description' => [
                 'nullable',
                 'string',
-                'max:500',
+                'max:5000',
             ],
             // List of tag IDs
             'changes.tags' => [

--- a/app/Http/Requests/V1/TimeEntry/TimeEntryUpdateRequest.php
+++ b/app/Http/Requests/V1/TimeEntry/TimeEntryUpdateRequest.php
@@ -77,7 +77,7 @@ class TimeEntryUpdateRequest extends BaseFormRequest
             'description' => [
                 'nullable',
                 'string',
-                'max:500',
+                'max:5000',
             ],
             // List of tag IDs
             'tags' => [

--- a/app/Service/Import/Importers/ClockifyTimeEntriesImporter.php
+++ b/app/Service/Import/Importers/ClockifyTimeEntriesImporter.php
@@ -112,7 +112,7 @@ class ClockifyTimeEntriesImporter extends DefaultImporter
                 $timeEntry->project_id = $projectId;
                 $timeEntry->client_id = $clientId;
                 $timeEntry->organization_id = $this->organization->id;
-                if (strlen($record['Description']) > 500) {
+                if (strlen($record['Description']) > 5000) {
                     throw new ImportException('Time entry description is too long');
                 }
                 $timeEntry->description = $record['Description'];

--- a/app/Service/Import/Importers/HarvestTimeEntriesImporter.php
+++ b/app/Service/Import/Importers/HarvestTimeEntriesImporter.php
@@ -107,7 +107,7 @@ class HarvestTimeEntriesImporter extends DefaultImporter
                 $timeEntry->project_id = $projectId;
                 $timeEntry->client_id = $clientId;
                 $timeEntry->organization_id = $this->organization->id;
-                if (strlen($record['Notes']) > 500) {
+                if (strlen($record['Notes']) > 5000) {
                     throw new ImportException('Time entry note is too long');
                 }
                 $timeEntry->description = $record['Notes'];

--- a/app/Service/Import/Importers/SolidtimeImporter.php
+++ b/app/Service/Import/Importers/SolidtimeImporter.php
@@ -247,7 +247,7 @@ class SolidtimeImporter extends DefaultImporter
                 $timeEntry->project_id = $projectId;
                 $timeEntry->client_id = $clientId;
                 $timeEntry->organization_id = $this->organization->id;
-                if (strlen($timeEntryRow['description']) > 500) {
+                if (strlen($timeEntryRow['description']) > 5000) {
                     throw new ImportException('Time entry description is too long');
                 }
                 $timeEntry->description = $timeEntryRow['description'];

--- a/database/migrations/2025_10_16_000001_extend_time_entry_description.php
+++ b/database/migrations/2025_10_16_000001_extend_time_entry_description.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('time_entries', function (Blueprint $table): void {
+            $table->string('description', 5000)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('time_entries', function (Blueprint $table): void {
+            $table->string('description', 500)->change();
+        });
+    }
+};

--- a/database/schema/pgsql_test-schema.sql
+++ b/database/schema/pgsql_test-schema.sql
@@ -435,7 +435,7 @@ CREATE TABLE public.tasks (
 
 CREATE TABLE public.time_entries (
     id uuid NOT NULL,
-    description character varying(500) NOT NULL,
+    description character varying(5000) NOT NULL,
     start timestamp(0) without time zone NOT NULL,
     "end" timestamp(0) without time zone,
     billable_rate integer,


### PR DESCRIPTION
## What does this PR do?

- Changed schema to allow 5000 instead of 500 chars for the time entry description
- Fixes #914

## Checklist (DO NOT REMOVE)

- [x] I read the [contributing guide](https://github.com/solidtime-io/solidtime/blob/main/CONTRIBUTING.md)
- [x] I signed the [Contributor License Agreement](https://cla-assistant.io/solidtime-io/solidtime).
- [x] I commented my code, particularly in hard-to-understand areas
