### PR TITLE
Show clients that are assigned to the employee, closes #893

### DIFF
--- a/app/Providers/JetstreamServiceProvider.php
+++ b/app/Providers/JetstreamServiceProvider.php
@@ -109,6 +109,7 @@ class JetstreamServiceProvider extends ServiceProvider
             'tags:update',
             'tags:delete',
             'clients:view',
+            'clients:view:all',
             'clients:create',
             'clients:update',
             'clients:delete',
@@ -172,6 +173,7 @@ class JetstreamServiceProvider extends ServiceProvider
             'tags:update',
             'tags:delete',
             'clients:view',
+            'clients:view:all',
             'clients:create',
             'clients:update',
             'clients:delete',
@@ -232,6 +234,7 @@ class JetstreamServiceProvider extends ServiceProvider
             'tags:update',
             'tags:delete',
             'clients:view',
+            'clients:view:all',
             'clients:create',
             'clients:update',
             'clients:delete',
@@ -256,12 +259,13 @@ class JetstreamServiceProvider extends ServiceProvider
             'projects:view',
             'tags:view',
             'tasks:view',
+            'clients:view',
             'time-entries:view:own',
             'time-entries:create:own',
             'time-entries:update:own',
             'time-entries:delete:own',
             'organizations:view',
-        ])->description('Employees have the ability to read, create, and update their own time entries and they can see the projects that they are members of.');
+        ])->description('Employees have the ability to read, create, and update their own time entries, they can see the projects that they are members of and the clients they are assigned to.');
 
         Jetstream::role(Role::Placeholder->value, 'Placeholder', [
         ])->description('Placeholders are used for importing data. They cannot log in and have no permissions.');


### PR DESCRIPTION
## What does this PR do?

- Allow users with the Employee role to see clients assigned to them (as opposed to Managers, who can see all clients)
- I added a new `clients:view:all` permission comparable to `projects:view:all` (and `projects:view`) that already existed
- Tested and working on my self-hosted instance
- I'm not a PHP developer, please be kind
- Fixes #893

## Checklist (DO NOT REMOVE)

- [x] I read the [contributing guide](https://github.com/solidtime-io/solidtime/blob/main/CONTRIBUTING.md)
- [x] I signed the [Contributor License Agreement](https://cla-assistant.io/solidtime-io/solidtime).
- [x] I commented my code, particularly in hard-to-understand areas
