### PR TITLE
Sort projects by name

### DIFF
--- a/app/Http/Controllers/Api/V1/ProjectController.php
+++ b/app/Http/Controllers/Api/V1/ProjectController.php
@@ -48,7 +48,8 @@ class ProjectController extends Controller
         $user = $this->user();
 
         $projectsQuery = Project::query()
-            ->whereBelongsTo($organization, 'organization');
+            ->whereBelongsTo($organization, 'organization')
+            ->orderBy('name');
 
         if (! $canViewAllProjects) {
             $projectsQuery->visibleByEmployee($user);

--- a/database/factories/ProjectFactory.php
+++ b/database/factories/ProjectFactory.php
@@ -38,6 +38,15 @@ class ProjectFactory extends Factory
         ];
     }
 
+    public function named(string $name): self
+    {
+        return $this->state(function (array $attributes) use ($name): array {
+            return [
+                'name' => $name,
+            ];
+        });
+    }
+
     public function withEstimatedTime(): self
     {
         return $this->state(function (array $attributes): array {


### PR DESCRIPTION
## What does this PR do?

It sorts projects by name on the non-admin UI. Without this PR, the projects are unsorted, i.e. in insertion order, which caused usability problems with our >30 entries.

One of the existing tests relied on the default insertion time ordering; I changed it to leverage the name now.

It's probably better not to rely on the sort order at all, but rather look up all projects in the JSON response: is it expected to be included, if so, does the billable rate show up or not?

## Checklist (DO NOT REMOVE)

- [x] I read the [contributing guide](https://github.com/solidtime-io/solidtime/blob/main/CONTRIBUTING.md)
- [x] I signed the [Contributor License Agreement](https://cla-assistant.io/solidtime-io/solidtime).
- [x] I commented my code, particularly in hard-to-understand areas
