### PR TITLE
Sort members by name

### DIFF
--- a/app/Http/Controllers/Api/V1/MemberController.php
+++ b/app/Http/Controllers/Api/V1/MemberController.php
@@ -62,6 +62,7 @@ class MemberController extends Controller
             ->with(['user'])
             ->join('users', 'members.user_id', '=', 'users.id')
             ->orderBy('users.name')
+            ->select('members.*')
             ->paginate(config('app.pagination_per_page_default'));
 
         return MemberCollection::make($members);

--- a/tests/Unit/Endpoint/Api/V1/MemberEndpointTest.php
+++ b/tests/Unit/Endpoint/Api/V1/MemberEndpointTest.php
@@ -72,6 +72,8 @@ class MemberEndpointTest extends ApiEndpointTestAbstract
 
         $memberNames = $members->merge([$data->member, $data->ownerMember])->pluck('user.name')->sort()->values()->all();
         $this->assertEquals($memberNames, $response->json('data.*.name'));
+
+        $this->assertNotEquals($response->json('data.*.id'), $response->json('data.*.user_id'));
     }
 
     public function test_update_member_fails_if_user_has_no_permission_to_update_members(): void


### PR DESCRIPTION
## What does this PR do?

Comparable to #963: We have many entries on the non-admin members page that are currently unsorted and hard to manage. This PR adds sorting by members' user names.

I don't know if there is a more effective way, given that `users` have been eagerly loaded before this PR. I'm not sure if users are loaded twice now: once via eager loading with `with`, and now a second time by now joining them to `members`.

I tried [adding `orderBy` to the `with` clause](https://stackoverflow.com/a/44355321/149264) to cause the member list to be sorted by user name. But that will only sort the eagerly loaded user list without causing the desired effect.

## Checklist (DO NOT REMOVE)

- [x] I read the [contributing guide](https://github.com/solidtime-io/solidtime/blob/main/CONTRIBUTING.md)
- [x] I signed the [Contributor License Agreement](https://cla-assistant.io/solidtime-io/solidtime).
- [x] I commented my code, particularly in hard-to-understand areas
