### PR TITLE
fix(import): gracefully handle orphaned client references in Toggl importer

### DIFF
--- a/app/Service/Import/Importers/TogglDataImporter.php
+++ b/app/Service/Import/Importers/TogglDataImporter.php
@@ -127,7 +127,11 @@ class TogglDataImporter extends DefaultImporter
                 if ($project->client_id !== null) {
                     $clientId = $this->clientImportHelper->getKeyByExternalIdentifier((string) $project->client_id);
                     if ($clientId === null) {
-                        throw new Exception('Client does not exist');
+                        // Client was deleted in Toggl but still referenced by a project — skip gracefully
+                        Log::warning('TogglDataImporter: Project references a non-existent client, importing without client', [
+                            'project_name' => $project->name,
+                            'client_id' => $project->client_id,
+                        ]);
                     }
                 }
 


### PR DESCRIPTION
## Summary

When importing a Toggl data export, the importer throws an unhandled `Exception("Client does not exist")` if a project references a `client_id` that isn't present in `clients.json`. This happens when a client was deleted in Toggl but the project still carries the old reference. The exception gets swallowed into a generic "Unknown error" response, giving the user no actionable feedback.

The fix skips the missing client reference (leaving the project with no client) and logs a warning instead of aborting the entire import.

## What changed

- `TogglDataImporter.php`: replaced `throw new Exception('Client does not exist')` with a `Log::warning()` when a project's `client_id` has no matching entry in the imported clients. The project is still imported, just without a client assigned.

## How I tested it

Reproduced by running a Toggl export where one project referenced a since-deleted client. Before this change: full import fails with "Unknown error". After: import completes, the orphaned project is imported without a client, warning appears in the log.

## Notes

The deleted client can't be recovered from the export, so silently dropping the reference is the most reasonable fallback. If a stricter behavior is preferred, the warning message makes it easy to surface this in the UI later.