### PR TITLE
Add filter to include/exclude tags

### DIFF
--- a/app/Enums/TagMatchType.php
+++ b/app/Enums/TagMatchType.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+use Datomatic\LaravelEnumHelper\LaravelEnumHelper;
+
+enum TagMatchType: string
+{
+    use LaravelEnumHelper;
+
+    case Contains = 'contains';
+
+    case NotContains = 'not_contains';
+}

--- a/app/Http/Controllers/Api/V1/Public/ReportController.php
+++ b/app/Http/Controllers/Api/V1/Public/ReportController.php
@@ -59,7 +59,7 @@ class ReportController extends Controller
         $filter->addBillable($properties->billable);
         $filter->addMemberIdsFilter($properties->memberIds?->toArray());
         $filter->addProjectIdsFilter($properties->projectIds?->toArray());
-        $filter->addTagIdsFilter($properties->tagIds?->toArray());
+        $filter->addTagIdsFilter($properties->tagIds?->toArray(), $properties->tagFilter);
         $filter->addTaskIdsFilter($properties->taskIds?->toArray());
         $filter->addClientIdsFilter($properties->clientIds?->toArray());
         $timeEntriesQuery = $filter->get();

--- a/app/Http/Controllers/Api/V1/Public/ReportController.php
+++ b/app/Http/Controllers/Api/V1/Public/ReportController.php
@@ -59,7 +59,7 @@ class ReportController extends Controller
         $filter->addBillable($properties->billable);
         $filter->addMemberIdsFilter($properties->memberIds?->toArray());
         $filter->addProjectIdsFilter($properties->projectIds?->toArray());
-        $filter->addTagIdsFilter($properties->tagIds?->toArray(), $properties->tagFilter);
+        $filter->addTagIdsFilter($properties->tagIds?->toArray(), $properties->tagMatchType);
         $filter->addTaskIdsFilter($properties->taskIds?->toArray());
         $filter->addClientIdsFilter($properties->clientIds?->toArray());
         $timeEntriesQuery = $filter->get();

--- a/app/Http/Controllers/Api/V1/ReportController.php
+++ b/app/Http/Controllers/Api/V1/ReportController.php
@@ -96,7 +96,7 @@ class ReportController extends Controller
         $properties->setClientIds($request->input('properties.client_ids', null));
         $properties->setProjectIds($request->input('properties.project_ids', null));
         $properties->setTagIds($request->input('properties.tag_ids', null));
-        $properties->setTagFilter($request->input('properties.tag_filter', null));
+        $properties->setTagMatchType($request->input('properties.tag_match_type', null));
         $properties->setTaskIds($request->input('properties.task_ids', null));
         $properties->weekStart = $request->has('properties.week_start') ? Weekday::from($request->input('properties.week_start')) : $user->week_start;
         $timezone = $user->timezone;

--- a/app/Http/Controllers/Api/V1/ReportController.php
+++ b/app/Http/Controllers/Api/V1/ReportController.php
@@ -96,6 +96,7 @@ class ReportController extends Controller
         $properties->setClientIds($request->input('properties.client_ids', null));
         $properties->setProjectIds($request->input('properties.project_ids', null));
         $properties->setTagIds($request->input('properties.tag_ids', null));
+        $properties->setTagFilter($request->input('properties.tag_filter', null));
         $properties->setTaskIds($request->input('properties.task_ids', null));
         $properties->weekStart = $request->has('properties.week_start') ? Weekday::from($request->input('properties.week_start')) : $user->week_start;
         $timezone = $user->timezone;

--- a/app/Http/Controllers/Api/V1/ReportController.php
+++ b/app/Http/Controllers/Api/V1/ReportController.php
@@ -96,7 +96,7 @@ class ReportController extends Controller
         $properties->setClientIds($request->input('properties.client_ids', null));
         $properties->setProjectIds($request->input('properties.project_ids', null));
         $properties->setTagIds($request->input('properties.tag_ids', null));
-        $properties->setTagMatchType($request->input('properties.tag_match_type', null));
+        $properties->setTagMatchType($request->getPropertyTagMatchType());
         $properties->setTaskIds($request->input('properties.task_ids', null));
         $properties->weekStart = $request->has('properties.week_start') ? Weekday::from($request->input('properties.week_start')) : $user->week_start;
         $timezone = $user->timezone;

--- a/app/Http/Controllers/Api/V1/TimeEntryController.php
+++ b/app/Http/Controllers/Api/V1/TimeEntryController.php
@@ -203,7 +203,7 @@ class TimeEntryController extends Controller
         $filter->addMemberIdFilter($member);
         $filter->addMemberIdsFilter($request->input('member_ids'));
         $filter->addProjectIdsFilter($request->input('project_ids'));
-        $filter->addTagIdsFilter($request->input('tag_ids'));
+        $filter->addTagIdsFilter($request->input('tag_ids'), $request->input('tag_filter'));
         $filter->addTaskIdsFilter($request->input('task_ids'));
         $filter->addClientIdsFilter($request->input('client_ids'));
         $filter->addBillableFilter($request->input('billable'));
@@ -559,7 +559,7 @@ class TimeEntryController extends Controller
         $filter->addMemberIdFilter($member);
         $filter->addMemberIdsFilter($request->input('member_ids'));
         $filter->addProjectIdsFilter($request->input('project_ids'));
-        $filter->addTagIdsFilter($request->input('tag_ids'));
+        $filter->addTagIdsFilter($request->input('tag_ids'), $request->input('tag_filter'));
         $filter->addTaskIdsFilter($request->input('task_ids'));
         $filter->addClientIdsFilter($request->input('client_ids'));
         $filter->addBillableFilter($request->input('billable'));

--- a/app/Http/Controllers/Api/V1/TimeEntryController.php
+++ b/app/Http/Controllers/Api/V1/TimeEntryController.php
@@ -203,7 +203,7 @@ class TimeEntryController extends Controller
         $filter->addMemberIdFilter($member);
         $filter->addMemberIdsFilter($request->input('member_ids'));
         $filter->addProjectIdsFilter($request->input('project_ids'));
-        $filter->addTagIdsFilter($request->input('tag_ids'), $request->input('tag_match_type'));
+        $filter->addTagIdsFilter($request->input('tag_ids'), $request->getTagMatchType());
         $filter->addTaskIdsFilter($request->input('task_ids'));
         $filter->addClientIdsFilter($request->input('client_ids'));
         $filter->addBillableFilter($request->input('billable'));
@@ -559,7 +559,7 @@ class TimeEntryController extends Controller
         $filter->addMemberIdFilter($member);
         $filter->addMemberIdsFilter($request->input('member_ids'));
         $filter->addProjectIdsFilter($request->input('project_ids'));
-        $filter->addTagIdsFilter($request->input('tag_ids'), $request->input('tag_match_type'));
+        $filter->addTagIdsFilter($request->input('tag_ids'), $request->getTagMatchType());
         $filter->addTaskIdsFilter($request->input('task_ids'));
         $filter->addClientIdsFilter($request->input('client_ids'));
         $filter->addBillableFilter($request->input('billable'));

--- a/app/Http/Controllers/Api/V1/TimeEntryController.php
+++ b/app/Http/Controllers/Api/V1/TimeEntryController.php
@@ -203,7 +203,7 @@ class TimeEntryController extends Controller
         $filter->addMemberIdFilter($member);
         $filter->addMemberIdsFilter($request->input('member_ids'));
         $filter->addProjectIdsFilter($request->input('project_ids'));
-        $filter->addTagIdsFilter($request->input('tag_ids'), $request->input('tag_filter'));
+        $filter->addTagIdsFilter($request->input('tag_ids'), $request->input('tag_match_type'));
         $filter->addTaskIdsFilter($request->input('task_ids'));
         $filter->addClientIdsFilter($request->input('client_ids'));
         $filter->addBillableFilter($request->input('billable'));
@@ -559,7 +559,7 @@ class TimeEntryController extends Controller
         $filter->addMemberIdFilter($member);
         $filter->addMemberIdsFilter($request->input('member_ids'));
         $filter->addProjectIdsFilter($request->input('project_ids'));
-        $filter->addTagIdsFilter($request->input('tag_ids'), $request->input('tag_filter'));
+        $filter->addTagIdsFilter($request->input('tag_ids'), $request->input('tag_match_type'));
         $filter->addTaskIdsFilter($request->input('task_ids'));
         $filter->addClientIdsFilter($request->input('client_ids'));
         $filter->addBillableFilter($request->input('billable'));

--- a/app/Http/Requests/V1/Report/ReportStoreRequest.php
+++ b/app/Http/Requests/V1/Report/ReportStoreRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\V1\Report;
 
+use App\Enums\TagMatchType;
 use App\Enums\TimeEntryAggregationType;
 use App\Enums\TimeEntryAggregationTypeInterval;
 use App\Enums\TimeEntryRoundingType;
@@ -127,7 +128,7 @@ class ReportStoreRequest extends BaseFormRequest
             'properties.tag_match_type' => [
                 'nullable',
                 'string',
-                'in:'.TimeEntryFilter::TAG_MATCH_TYPE_CONTAINS.','.TimeEntryFilter::TAG_MATCH_TYPE_NOT_CONTAINS,
+                Rule::enum(TagMatchType::class),
             ],
             'properties.task_ids' => [
                 'nullable',
@@ -252,6 +253,15 @@ class ReportStoreRequest extends BaseFormRequest
     public function getPropertyHistoryGroup(): TimeEntryAggregationTypeInterval
     {
         return TimeEntryAggregationTypeInterval::from($this->input('properties.history_group'));
+    }
+
+    public function getPropertyTagMatchType(): ?TagMatchType
+    {
+        if (! $this->has('properties.tag_match_type') || $this->input('properties.tag_match_type') === null) {
+            return null;
+        }
+
+        return TagMatchType::from($this->input('properties.tag_match_type'));
     }
 
     public function getPropertyRoundingType(): ?TimeEntryRoundingType

--- a/app/Http/Requests/V1/Report/ReportStoreRequest.php
+++ b/app/Http/Requests/V1/Report/ReportStoreRequest.php
@@ -124,6 +124,11 @@ class ReportStoreRequest extends BaseFormRequest
                     }
                 },
             ],
+            'properties.tag_filter' => [
+                'nullable',
+                'string',
+                'in:'.TimeEntryFilter::TAG_FILTER_CONTAINS.','.TimeEntryFilter::TAG_FILTER_NOT_CONTAINS,
+            ],
             'properties.task_ids' => [
                 'nullable',
                 'array',

--- a/app/Http/Requests/V1/Report/ReportStoreRequest.php
+++ b/app/Http/Requests/V1/Report/ReportStoreRequest.php
@@ -124,10 +124,10 @@ class ReportStoreRequest extends BaseFormRequest
                     }
                 },
             ],
-            'properties.tag_filter' => [
+            'properties.tag_match_type' => [
                 'nullable',
                 'string',
-                'in:'.TimeEntryFilter::TAG_FILTER_CONTAINS.','.TimeEntryFilter::TAG_FILTER_NOT_CONTAINS,
+                'in:'.TimeEntryFilter::TAG_MATCH_TYPE_CONTAINS.','.TimeEntryFilter::TAG_MATCH_TYPE_NOT_CONTAINS,
             ],
             'properties.task_ids' => [
                 'nullable',

--- a/app/Http/Requests/V1/TimeEntry/TimeEntryAggregateExportRequest.php
+++ b/app/Http/Requests/V1/TimeEntry/TimeEntryAggregateExportRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Requests\V1\TimeEntry;
 
 use App\Enums\ExportFormat;
+use App\Enums\TagMatchType;
 use App\Enums\TimeEntryAggregationType;
 use App\Enums\TimeEntryAggregationTypeInterval;
 use App\Enums\TimeEntryRoundingType;
@@ -141,7 +142,7 @@ class TimeEntryAggregateExportRequest extends BaseFormRequest
             ],
             'tag_match_type' => [
                 'string',
-                'in:'.TimeEntryFilter::TAG_MATCH_TYPE_CONTAINS.','.TimeEntryFilter::TAG_MATCH_TYPE_NOT_CONTAINS,
+                Rule::enum(TagMatchType::class),
             ],
             // Filter by task IDs, task IDs are OR combined
             'task_ids' => [
@@ -248,6 +249,15 @@ class TimeEntryAggregateExportRequest extends BaseFormRequest
     public function getFormatValue(): ExportFormat
     {
         return ExportFormat::from($this->validated('format'));
+    }
+
+    public function getTagMatchType(): ?TagMatchType
+    {
+        if (! $this->has('tag_match_type') || $this->validated('tag_match_type') === null) {
+            return null;
+        }
+
+        return TagMatchType::from($this->validated('tag_match_type'));
     }
 
     public function getRoundingType(): ?TimeEntryRoundingType

--- a/app/Http/Requests/V1/TimeEntry/TimeEntryAggregateExportRequest.php
+++ b/app/Http/Requests/V1/TimeEntry/TimeEntryAggregateExportRequest.php
@@ -139,9 +139,9 @@ class TimeEntryAggregateExportRequest extends BaseFormRequest
                     })->uuid()->validate($attribute, $value, $fail);
                 },
             ],
-            'tag_filter' => [
+            'tag_match_type' => [
                 'string',
-                'in:'.TimeEntryFilter::TAG_FILTER_CONTAINS.','.TimeEntryFilter::TAG_FILTER_NOT_CONTAINS,
+                'in:'.TimeEntryFilter::TAG_MATCH_TYPE_CONTAINS.','.TimeEntryFilter::TAG_MATCH_TYPE_NOT_CONTAINS,
             ],
             // Filter by task IDs, task IDs are OR combined
             'task_ids' => [

--- a/app/Http/Requests/V1/TimeEntry/TimeEntryAggregateExportRequest.php
+++ b/app/Http/Requests/V1/TimeEntry/TimeEntryAggregateExportRequest.php
@@ -139,6 +139,10 @@ class TimeEntryAggregateExportRequest extends BaseFormRequest
                     })->uuid()->validate($attribute, $value, $fail);
                 },
             ],
+            'tag_filter' => [
+                'string',
+                'in:'.TimeEntryFilter::TAG_FILTER_CONTAINS.','.TimeEntryFilter::TAG_FILTER_NOT_CONTAINS,
+            ],
             // Filter by task IDs, task IDs are OR combined
             'task_ids' => [
                 'array',

--- a/app/Http/Requests/V1/TimeEntry/TimeEntryAggregateRequest.php
+++ b/app/Http/Requests/V1/TimeEntry/TimeEntryAggregateRequest.php
@@ -125,6 +125,10 @@ class TimeEntryAggregateRequest extends BaseFormRequest
                     })->uuid()->validate($attribute, $value, $fail);
                 },
             ],
+            'tag_filter' => [
+                'string',
+                'in:'.TimeEntryFilter::TAG_FILTER_CONTAINS.','.TimeEntryFilter::TAG_FILTER_NOT_CONTAINS,
+            ],
             // Filter by task IDs, task IDs are OR combined
             'task_ids' => [
                 'array',

--- a/app/Http/Requests/V1/TimeEntry/TimeEntryAggregateRequest.php
+++ b/app/Http/Requests/V1/TimeEntry/TimeEntryAggregateRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\V1\TimeEntry;
 
+use App\Enums\TagMatchType;
 use App\Enums\TimeEntryAggregationType;
 use App\Enums\TimeEntryRoundingType;
 use App\Http\Requests\V1\BaseFormRequest;
@@ -127,7 +128,7 @@ class TimeEntryAggregateRequest extends BaseFormRequest
             ],
             'tag_match_type' => [
                 'string',
-                'in:'.TimeEntryFilter::TAG_MATCH_TYPE_CONTAINS.','.TimeEntryFilter::TAG_MATCH_TYPE_NOT_CONTAINS,
+                Rule::enum(TagMatchType::class),
             ],
             // Filter by task IDs, task IDs are OR combined
             'task_ids' => [
@@ -210,6 +211,15 @@ class TimeEntryAggregateRequest extends BaseFormRequest
     public function getEnd(): ?Carbon
     {
         return $this->input('end') !== null ? Carbon::createFromFormat('Y-m-d\TH:i:s\Z', $this->input('end'), 'UTC') : null;
+    }
+
+    public function getTagMatchType(): ?TagMatchType
+    {
+        if (! $this->has('tag_match_type') || $this->validated('tag_match_type') === null) {
+            return null;
+        }
+
+        return TagMatchType::from($this->validated('tag_match_type'));
     }
 
     public function getRoundingType(): ?TimeEntryRoundingType

--- a/app/Http/Requests/V1/TimeEntry/TimeEntryAggregateRequest.php
+++ b/app/Http/Requests/V1/TimeEntry/TimeEntryAggregateRequest.php
@@ -125,9 +125,9 @@ class TimeEntryAggregateRequest extends BaseFormRequest
                     })->uuid()->validate($attribute, $value, $fail);
                 },
             ],
-            'tag_filter' => [
+            'tag_match_type' => [
                 'string',
-                'in:'.TimeEntryFilter::TAG_FILTER_CONTAINS.','.TimeEntryFilter::TAG_FILTER_NOT_CONTAINS,
+                'in:'.TimeEntryFilter::TAG_MATCH_TYPE_CONTAINS.','.TimeEntryFilter::TAG_MATCH_TYPE_NOT_CONTAINS,
             ],
             // Filter by task IDs, task IDs are OR combined
             'task_ids' => [

--- a/app/Http/Requests/V1/TimeEntry/TimeEntryIndexExportRequest.php
+++ b/app/Http/Requests/V1/TimeEntry/TimeEntryIndexExportRequest.php
@@ -110,9 +110,9 @@ class TimeEntryIndexExportRequest extends TimeEntryIndexRequest
                     })->uuid()->validate($attribute, $value, $fail);
                 },
             ],
-            'tag_filter' => [
+            'tag_match_type' => [
                 'string',
-                'in:'.TimeEntryFilter::TAG_FILTER_CONTAINS.','.TimeEntryFilter::TAG_FILTER_NOT_CONTAINS,
+                'in:'.TimeEntryFilter::TAG_MATCH_TYPE_CONTAINS.','.TimeEntryFilter::TAG_MATCH_TYPE_NOT_CONTAINS,
             ],
             // Filter by task IDs, task IDs are OR combined
             'task_ids' => [

--- a/app/Http/Requests/V1/TimeEntry/TimeEntryIndexExportRequest.php
+++ b/app/Http/Requests/V1/TimeEntry/TimeEntryIndexExportRequest.php
@@ -110,6 +110,10 @@ class TimeEntryIndexExportRequest extends TimeEntryIndexRequest
                     })->uuid()->validate($attribute, $value, $fail);
                 },
             ],
+            'tag_filter' => [
+                'string',
+                'in:'.TimeEntryFilter::TAG_FILTER_CONTAINS.','.TimeEntryFilter::TAG_FILTER_NOT_CONTAINS,
+            ],
             // Filter by task IDs, task IDs are OR combined
             'task_ids' => [
                 'array',

--- a/app/Http/Requests/V1/TimeEntry/TimeEntryIndexExportRequest.php
+++ b/app/Http/Requests/V1/TimeEntry/TimeEntryIndexExportRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Requests\V1\TimeEntry;
 
 use App\Enums\ExportFormat;
+use App\Enums\TagMatchType;
 use App\Enums\TimeEntryRoundingType;
 use App\Models\Client;
 use App\Models\Member;
@@ -112,7 +113,7 @@ class TimeEntryIndexExportRequest extends TimeEntryIndexRequest
             ],
             'tag_match_type' => [
                 'string',
-                'in:'.TimeEntryFilter::TAG_MATCH_TYPE_CONTAINS.','.TimeEntryFilter::TAG_MATCH_TYPE_NOT_CONTAINS,
+                Rule::enum(TagMatchType::class),
             ],
             // Filter by task IDs, task IDs are OR combined
             'task_ids' => [
@@ -217,6 +218,15 @@ class TimeEntryIndexExportRequest extends TimeEntryIndexRequest
     public function getFormatValue(): ExportFormat
     {
         return ExportFormat::from($this->validated('format'));
+    }
+
+    public function getTagMatchType(): ?TagMatchType
+    {
+        if (! $this->has('tag_match_type') || $this->validated('tag_match_type') === null) {
+            return null;
+        }
+
+        return TagMatchType::from($this->validated('tag_match_type'));
     }
 
     public function getRoundingType(): ?TimeEntryRoundingType

--- a/app/Http/Requests/V1/TimeEntry/TimeEntryIndexRequest.php
+++ b/app/Http/Requests/V1/TimeEntry/TimeEntryIndexRequest.php
@@ -103,6 +103,10 @@ class TimeEntryIndexRequest extends BaseFormRequest
                     })->uuid()->validate($attribute, $value, $fail);
                 },
             ],
+            'tag_filter' => [
+                'string',
+                'in:'.TimeEntryFilter::TAG_FILTER_CONTAINS.','.TimeEntryFilter::TAG_FILTER_NOT_CONTAINS,
+            ],
             // Filter by task IDs, task IDs are OR combined
             'task_ids' => [
                 'array',

--- a/app/Http/Requests/V1/TimeEntry/TimeEntryIndexRequest.php
+++ b/app/Http/Requests/V1/TimeEntry/TimeEntryIndexRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\V1\TimeEntry;
 
+use App\Enums\TagMatchType;
 use App\Enums\TimeEntryRoundingType;
 use App\Http\Requests\V1\BaseFormRequest;
 use App\Models\Client;
@@ -105,7 +106,7 @@ class TimeEntryIndexRequest extends BaseFormRequest
             ],
             'tag_match_type' => [
                 'string',
-                'in:'.TimeEntryFilter::TAG_MATCH_TYPE_CONTAINS.','.TimeEntryFilter::TAG_MATCH_TYPE_NOT_CONTAINS,
+                Rule::enum(TagMatchType::class),
             ],
             // Filter by task IDs, task IDs are OR combined
             'task_ids' => [
@@ -192,6 +193,15 @@ class TimeEntryIndexRequest extends BaseFormRequest
     public function getOffset(): int
     {
         return $this->has('offset') ? (int) $this->validated('offset', 0) : 0;
+    }
+
+    public function getTagMatchType(): ?TagMatchType
+    {
+        if (! $this->has('tag_match_type') || $this->validated('tag_match_type') === null) {
+            return null;
+        }
+
+        return TagMatchType::from($this->validated('tag_match_type'));
     }
 
     public function getRoundingType(): ?TimeEntryRoundingType

--- a/app/Http/Requests/V1/TimeEntry/TimeEntryIndexRequest.php
+++ b/app/Http/Requests/V1/TimeEntry/TimeEntryIndexRequest.php
@@ -103,9 +103,9 @@ class TimeEntryIndexRequest extends BaseFormRequest
                     })->uuid()->validate($attribute, $value, $fail);
                 },
             ],
-            'tag_filter' => [
+            'tag_match_type' => [
                 'string',
-                'in:'.TimeEntryFilter::TAG_FILTER_CONTAINS.','.TimeEntryFilter::TAG_FILTER_NOT_CONTAINS,
+                'in:'.TimeEntryFilter::TAG_MATCH_TYPE_CONTAINS.','.TimeEntryFilter::TAG_MATCH_TYPE_NOT_CONTAINS,
             ],
             // Filter by task IDs, task IDs are OR combined
             'task_ids' => [

--- a/app/Http/Resources/V1/Report/DetailedReportResource.php
+++ b/app/Http/Resources/V1/Report/DetailedReportResource.php
@@ -56,6 +56,8 @@ class DetailedReportResource extends BaseResource
                 'project_ids' => $this->resource->properties->projectIds?->toArray(),
                 /** @var array<string>|null $tags_ids Filter by tag IDs, tag IDs are OR combined */
                 'tag_ids' => $this->resource->properties->tagIds?->toArray(),
+                /** @var string|null $tag_filter Tag filter mode */
+                'tag_filter' => $this->resource->properties->tagFilter,
                 /** @var array<string>|null $task_ids Filter by task IDs, task IDs are OR combined */
                 'task_ids' => $this->resource->properties->taskIds?->toArray(),
                 /** @var string|null $rounding_type Rounding type for time entries */

--- a/app/Http/Resources/V1/Report/DetailedReportResource.php
+++ b/app/Http/Resources/V1/Report/DetailedReportResource.php
@@ -57,7 +57,7 @@ class DetailedReportResource extends BaseResource
                 /** @var array<string>|null $tags_ids Filter by tag IDs, tag IDs are OR combined */
                 'tag_ids' => $this->resource->properties->tagIds?->toArray(),
                 /** @var string|null $tag_match_type Tag match type */
-                'tag_match_type' => $this->resource->properties->tagMatchType,
+                'tag_match_type' => $this->resource->properties->tagMatchType?->value,
                 /** @var array<string>|null $task_ids Filter by task IDs, task IDs are OR combined */
                 'task_ids' => $this->resource->properties->taskIds?->toArray(),
                 /** @var string|null $rounding_type Rounding type for time entries */

--- a/app/Http/Resources/V1/Report/DetailedReportResource.php
+++ b/app/Http/Resources/V1/Report/DetailedReportResource.php
@@ -56,8 +56,8 @@ class DetailedReportResource extends BaseResource
                 'project_ids' => $this->resource->properties->projectIds?->toArray(),
                 /** @var array<string>|null $tags_ids Filter by tag IDs, tag IDs are OR combined */
                 'tag_ids' => $this->resource->properties->tagIds?->toArray(),
-                /** @var string|null $tag_filter Tag filter mode */
-                'tag_filter' => $this->resource->properties->tagFilter,
+                /** @var string|null $tag_match_type Tag match type */
+                'tag_match_type' => $this->resource->properties->tagMatchType,
                 /** @var array<string>|null $task_ids Filter by task IDs, task IDs are OR combined */
                 'task_ids' => $this->resource->properties->taskIds?->toArray(),
                 /** @var string|null $rounding_type Rounding type for time entries */

--- a/app/Service/Dto/ReportPropertiesDto.php
+++ b/app/Service/Dto/ReportPropertiesDto.php
@@ -56,6 +56,8 @@ class ReportPropertiesDto implements Castable
      */
     public ?Collection $tagIds = null;
 
+    public ?string $tagFilter = null;
+
     /**
      * @var Collection<int, string>|null
      */
@@ -115,6 +117,7 @@ class ReportPropertiesDto implements Castable
                 $dto->clientIds = $data->clientIds !== null ? ReportPropertiesDto::idArrayToCollection($data->clientIds) : null;
                 $dto->projectIds = $data->projectIds !== null ? ReportPropertiesDto::idArrayToCollection($data->projectIds) : null;
                 $dto->tagIds = $data->tagIds !== null ? ReportPropertiesDto::idArrayToCollection($data->tagIds) : null;
+                $dto->tagFilter = isset($data->tagFilter) ? ReportPropertiesDto::tagFilterValue($data->tagFilter) : null;
                 $dto->taskIds = $data->taskIds ? ReportPropertiesDto::idArrayToCollection($data->taskIds) : null;
                 $dto->group = TimeEntryAggregationType::from($data->group);
                 $dto->subGroup = TimeEntryAggregationType::from($data->subGroup);
@@ -144,6 +147,7 @@ class ReportPropertiesDto implements Castable
                     'clientIds' => $value->clientIds?->toArray(),
                     'projectIds' => $value->projectIds?->toArray(),
                     'tagIds' => $value->tagIds?->toArray(),
+                    'tagFilter' => $value->tagFilter,
                     'taskIds' => $value->taskIds?->toArray(),
                     'group' => $value->group->value,
                     'subGroup' => $value->subGroup->value,
@@ -185,6 +189,24 @@ class ReportPropertiesDto implements Castable
     }
 
     /**
+     * @return 'contains'|'not_contains'|null
+     */
+    public static function tagFilterValue(mixed $tagFilter): ?string
+    {
+        if ($tagFilter === null) {
+            return null;
+        }
+        if (! is_string($tagFilter)) {
+            throw new \InvalidArgumentException('The given tag filter is not a string');
+        }
+        if (! in_array($tagFilter, [TimeEntryFilter::TAG_FILTER_CONTAINS, TimeEntryFilter::TAG_FILTER_NOT_CONTAINS], true)) {
+            throw new \InvalidArgumentException('The given tag filter is not valid');
+        }
+
+        return $tagFilter;
+    }
+
+    /**
      * @param  array<mixed>|null  $memberIds
      */
     public function setMemberIds(?array $memberIds): void
@@ -214,6 +236,11 @@ class ReportPropertiesDto implements Castable
     public function setTagIds(?array $tagIds): void
     {
         $this->tagIds = $tagIds !== null ? ReportPropertiesDto::idArrayToCollection($tagIds) : null;
+    }
+
+    public function setTagFilter(mixed $tagFilter): void
+    {
+        $this->tagFilter = ReportPropertiesDto::tagFilterValue($tagFilter);
     }
 
     /**

--- a/app/Service/Dto/ReportPropertiesDto.php
+++ b/app/Service/Dto/ReportPropertiesDto.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service\Dto;
 
+use App\Enums\TagMatchType;
 use App\Enums\TimeEntryAggregationType;
 use App\Enums\TimeEntryAggregationTypeInterval;
 use App\Enums\TimeEntryRoundingType;
@@ -56,7 +57,7 @@ class ReportPropertiesDto implements Castable
      */
     public ?Collection $tagIds = null;
 
-    public ?string $tagMatchType = null;
+    public ?TagMatchType $tagMatchType = null;
 
     /**
      * @var Collection<int, string>|null
@@ -117,7 +118,7 @@ class ReportPropertiesDto implements Castable
                 $dto->clientIds = $data->clientIds !== null ? ReportPropertiesDto::idArrayToCollection($data->clientIds) : null;
                 $dto->projectIds = $data->projectIds !== null ? ReportPropertiesDto::idArrayToCollection($data->projectIds) : null;
                 $dto->tagIds = $data->tagIds !== null ? ReportPropertiesDto::idArrayToCollection($data->tagIds) : null;
-                $dto->tagMatchType = isset($data->tagMatchType) ? ReportPropertiesDto::tagMatchTypeValue($data->tagMatchType) : null;
+                $dto->tagMatchType = isset($data->tagMatchType) ? TagMatchType::from($data->tagMatchType) : null;
                 $dto->taskIds = $data->taskIds ? ReportPropertiesDto::idArrayToCollection($data->taskIds) : null;
                 $dto->group = TimeEntryAggregationType::from($data->group);
                 $dto->subGroup = TimeEntryAggregationType::from($data->subGroup);
@@ -147,7 +148,7 @@ class ReportPropertiesDto implements Castable
                     'clientIds' => $value->clientIds?->toArray(),
                     'projectIds' => $value->projectIds?->toArray(),
                     'tagIds' => $value->tagIds?->toArray(),
-                    'tagMatchType' => $value->tagMatchType,
+                    'tagMatchType' => $value->tagMatchType?->value,
                     'taskIds' => $value->taskIds?->toArray(),
                     'group' => $value->group->value,
                     'subGroup' => $value->subGroup->value,
@@ -189,24 +190,6 @@ class ReportPropertiesDto implements Castable
     }
 
     /**
-     * @return 'contains'|'not_contains'|null
-     */
-    public static function tagMatchTypeValue(mixed $tagMatchType): ?string
-    {
-        if ($tagMatchType === null) {
-            return null;
-        }
-        if (! is_string($tagMatchType)) {
-            throw new \InvalidArgumentException('The given tag match type is not a string');
-        }
-        if (! in_array($tagMatchType, [TimeEntryFilter::TAG_MATCH_TYPE_CONTAINS, TimeEntryFilter::TAG_MATCH_TYPE_NOT_CONTAINS], true)) {
-            throw new \InvalidArgumentException('The given tag match type is not valid');
-        }
-
-        return $tagMatchType;
-    }
-
-    /**
      * @param  array<mixed>|null  $memberIds
      */
     public function setMemberIds(?array $memberIds): void
@@ -238,9 +221,9 @@ class ReportPropertiesDto implements Castable
         $this->tagIds = $tagIds !== null ? ReportPropertiesDto::idArrayToCollection($tagIds) : null;
     }
 
-    public function setTagMatchType(mixed $tagMatchType): void
+    public function setTagMatchType(?TagMatchType $tagMatchType): void
     {
-        $this->tagMatchType = ReportPropertiesDto::tagMatchTypeValue($tagMatchType);
+        $this->tagMatchType = $tagMatchType;
     }
 
     /**

--- a/app/Service/Dto/ReportPropertiesDto.php
+++ b/app/Service/Dto/ReportPropertiesDto.php
@@ -56,7 +56,7 @@ class ReportPropertiesDto implements Castable
      */
     public ?Collection $tagIds = null;
 
-    public ?string $tagFilter = null;
+    public ?string $tagMatchType = null;
 
     /**
      * @var Collection<int, string>|null
@@ -117,7 +117,7 @@ class ReportPropertiesDto implements Castable
                 $dto->clientIds = $data->clientIds !== null ? ReportPropertiesDto::idArrayToCollection($data->clientIds) : null;
                 $dto->projectIds = $data->projectIds !== null ? ReportPropertiesDto::idArrayToCollection($data->projectIds) : null;
                 $dto->tagIds = $data->tagIds !== null ? ReportPropertiesDto::idArrayToCollection($data->tagIds) : null;
-                $dto->tagFilter = isset($data->tagFilter) ? ReportPropertiesDto::tagFilterValue($data->tagFilter) : null;
+                $dto->tagMatchType = isset($data->tagMatchType) ? ReportPropertiesDto::tagMatchTypeValue($data->tagMatchType) : null;
                 $dto->taskIds = $data->taskIds ? ReportPropertiesDto::idArrayToCollection($data->taskIds) : null;
                 $dto->group = TimeEntryAggregationType::from($data->group);
                 $dto->subGroup = TimeEntryAggregationType::from($data->subGroup);
@@ -147,7 +147,7 @@ class ReportPropertiesDto implements Castable
                     'clientIds' => $value->clientIds?->toArray(),
                     'projectIds' => $value->projectIds?->toArray(),
                     'tagIds' => $value->tagIds?->toArray(),
-                    'tagFilter' => $value->tagFilter,
+                    'tagMatchType' => $value->tagMatchType,
                     'taskIds' => $value->taskIds?->toArray(),
                     'group' => $value->group->value,
                     'subGroup' => $value->subGroup->value,
@@ -191,19 +191,19 @@ class ReportPropertiesDto implements Castable
     /**
      * @return 'contains'|'not_contains'|null
      */
-    public static function tagFilterValue(mixed $tagFilter): ?string
+    public static function tagMatchTypeValue(mixed $tagMatchType): ?string
     {
-        if ($tagFilter === null) {
+        if ($tagMatchType === null) {
             return null;
         }
-        if (! is_string($tagFilter)) {
-            throw new \InvalidArgumentException('The given tag filter is not a string');
+        if (! is_string($tagMatchType)) {
+            throw new \InvalidArgumentException('The given tag match type is not a string');
         }
-        if (! in_array($tagFilter, [TimeEntryFilter::TAG_FILTER_CONTAINS, TimeEntryFilter::TAG_FILTER_NOT_CONTAINS], true)) {
-            throw new \InvalidArgumentException('The given tag filter is not valid');
+        if (! in_array($tagMatchType, [TimeEntryFilter::TAG_MATCH_TYPE_CONTAINS, TimeEntryFilter::TAG_MATCH_TYPE_NOT_CONTAINS], true)) {
+            throw new \InvalidArgumentException('The given tag match type is not valid');
         }
 
-        return $tagFilter;
+        return $tagMatchType;
     }
 
     /**
@@ -238,9 +238,9 @@ class ReportPropertiesDto implements Castable
         $this->tagIds = $tagIds !== null ? ReportPropertiesDto::idArrayToCollection($tagIds) : null;
     }
 
-    public function setTagFilter(mixed $tagFilter): void
+    public function setTagMatchType(mixed $tagMatchType): void
     {
-        $this->tagFilter = ReportPropertiesDto::tagFilterValue($tagFilter);
+        $this->tagMatchType = ReportPropertiesDto::tagMatchTypeValue($tagMatchType);
     }
 
     /**

--- a/app/Service/TimeEntryFilter.php
+++ b/app/Service/TimeEntryFilter.php
@@ -14,6 +14,10 @@ class TimeEntryFilter
 {
     public const string NONE_VALUE = 'none';
 
+    public const string TAG_FILTER_CONTAINS = 'contains';
+
+    public const string TAG_FILTER_NOT_CONTAINS = 'not_contains';
+
     /**
      * @var Builder<TimeEntry>
      */
@@ -192,15 +196,22 @@ class TimeEntryFilter
     /**
      * @param  array<string>|null  $tagIds
      */
-    public function addTagIdsFilter(?array $tagIds): self
+    public function addTagIdsFilter(?array $tagIds, ?string $tagFilter = self::TAG_FILTER_CONTAINS): self
     {
         if ($tagIds === null) {
             return $this;
         }
+        if ($tagFilter === null) {
+            $tagFilter = self::TAG_FILTER_CONTAINS;
+        }
+        if (! in_array($tagFilter, [self::TAG_FILTER_CONTAINS, self::TAG_FILTER_NOT_CONTAINS], true)) {
+            Log::warning('Invalid tag filter value', ['value' => $tagFilter]);
+            $tagFilter = self::TAG_FILTER_CONTAINS;
+        }
         $includeNone = in_array(self::NONE_VALUE, $tagIds, true);
         $tagIds = array_values(array_filter($tagIds, fn (string $id): bool => $id !== self::NONE_VALUE));
 
-        $this->builder->where(function (Builder $builder) use ($tagIds, $includeNone): void {
+        $tagCondition = function (Builder $builder) use ($tagIds, $includeNone): void {
             foreach ($tagIds as $tagId) {
                 $builder->orWhereJsonContains('tags', $tagId);
             }
@@ -209,7 +220,13 @@ class TimeEntryFilter
                     $query->whereJsonLength('tags', 0)->orWhereNull('tags');
                 });
             }
-        });
+        };
+
+        if ($tagFilter === self::TAG_FILTER_NOT_CONTAINS) {
+            $this->builder->whereNot($tagCondition);
+        } else {
+            $this->builder->where($tagCondition);
+        }
 
         return $this;
     }

--- a/app/Service/TimeEntryFilter.php
+++ b/app/Service/TimeEntryFilter.php
@@ -210,6 +210,11 @@ class TimeEntryFilter
         }
         $includeNone = in_array(self::NONE_VALUE, $tagIds, true);
         $tagIds = array_values(array_filter($tagIds, fn (string $id): bool => $id !== self::NONE_VALUE));
+        // An empty selection (no tag IDs and not filtering for "none") is no constraint, so apply nothing.
+        // This also prevents the not-contains branch from collapsing into "only entries with null tags".
+        if (count($tagIds) === 0 && ! $includeNone) {
+            return $this;
+        }
 
         $tagCondition = function (Builder $builder) use ($tagIds, $includeNone): void {
             foreach ($tagIds as $tagId) {
@@ -223,7 +228,12 @@ class TimeEntryFilter
         };
 
         if ($tagFilter === self::TAG_FILTER_NOT_CONTAINS) {
-            $this->builder->whereNot($tagCondition);
+            $this->builder->where(function (Builder $builder) use ($tagCondition, $includeNone): void {
+                $builder->whereNot($tagCondition);
+                if (! $includeNone) {
+                    $builder->orWhereNull('tags');
+                }
+            });
         } else {
             $this->builder->where($tagCondition);
         }

--- a/app/Service/TimeEntryFilter.php
+++ b/app/Service/TimeEntryFilter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Enums\TagMatchType;
 use App\Models\Member;
 use App\Models\TimeEntry;
 use Illuminate\Database\Eloquent\Builder;
@@ -13,10 +14,6 @@ use Illuminate\Support\Facades\Log;
 class TimeEntryFilter
 {
     public const string NONE_VALUE = 'none';
-
-    public const string TAG_MATCH_TYPE_CONTAINS = 'contains';
-
-    public const string TAG_MATCH_TYPE_NOT_CONTAINS = 'not_contains';
 
     /**
      * @var Builder<TimeEntry>
@@ -196,18 +193,12 @@ class TimeEntryFilter
     /**
      * @param  array<string>|null  $tagIds
      */
-    public function addTagIdsFilter(?array $tagIds, ?string $tagMatchType = self::TAG_MATCH_TYPE_CONTAINS): self
+    public function addTagIdsFilter(?array $tagIds, ?TagMatchType $tagMatchType = TagMatchType::Contains): self
     {
         if ($tagIds === null) {
             return $this;
         }
-        if ($tagMatchType === null) {
-            $tagMatchType = self::TAG_MATCH_TYPE_CONTAINS;
-        }
-        if (! in_array($tagMatchType, [self::TAG_MATCH_TYPE_CONTAINS, self::TAG_MATCH_TYPE_NOT_CONTAINS], true)) {
-            Log::warning('Invalid tag match type value', ['value' => $tagMatchType]);
-            $tagMatchType = self::TAG_MATCH_TYPE_CONTAINS;
-        }
+        $tagMatchType ??= TagMatchType::Contains;
         $includeNone = in_array(self::NONE_VALUE, $tagIds, true);
         $tagIds = array_values(array_filter($tagIds, fn (string $id): bool => $id !== self::NONE_VALUE));
         // An empty selection (no tag IDs and not filtering for "none") is no constraint, so apply nothing.
@@ -227,7 +218,7 @@ class TimeEntryFilter
             }
         };
 
-        if ($tagMatchType === self::TAG_MATCH_TYPE_NOT_CONTAINS) {
+        if ($tagMatchType === TagMatchType::NotContains) {
             $this->builder->where(function (Builder $builder) use ($tagCondition, $includeNone): void {
                 $builder->whereNot($tagCondition);
                 if (! $includeNone) {

--- a/app/Service/TimeEntryFilter.php
+++ b/app/Service/TimeEntryFilter.php
@@ -14,9 +14,9 @@ class TimeEntryFilter
 {
     public const string NONE_VALUE = 'none';
 
-    public const string TAG_FILTER_CONTAINS = 'contains';
+    public const string TAG_MATCH_TYPE_CONTAINS = 'contains';
 
-    public const string TAG_FILTER_NOT_CONTAINS = 'not_contains';
+    public const string TAG_MATCH_TYPE_NOT_CONTAINS = 'not_contains';
 
     /**
      * @var Builder<TimeEntry>
@@ -196,17 +196,17 @@ class TimeEntryFilter
     /**
      * @param  array<string>|null  $tagIds
      */
-    public function addTagIdsFilter(?array $tagIds, ?string $tagFilter = self::TAG_FILTER_CONTAINS): self
+    public function addTagIdsFilter(?array $tagIds, ?string $tagMatchType = self::TAG_MATCH_TYPE_CONTAINS): self
     {
         if ($tagIds === null) {
             return $this;
         }
-        if ($tagFilter === null) {
-            $tagFilter = self::TAG_FILTER_CONTAINS;
+        if ($tagMatchType === null) {
+            $tagMatchType = self::TAG_MATCH_TYPE_CONTAINS;
         }
-        if (! in_array($tagFilter, [self::TAG_FILTER_CONTAINS, self::TAG_FILTER_NOT_CONTAINS], true)) {
-            Log::warning('Invalid tag filter value', ['value' => $tagFilter]);
-            $tagFilter = self::TAG_FILTER_CONTAINS;
+        if (! in_array($tagMatchType, [self::TAG_MATCH_TYPE_CONTAINS, self::TAG_MATCH_TYPE_NOT_CONTAINS], true)) {
+            Log::warning('Invalid tag match type value', ['value' => $tagMatchType]);
+            $tagMatchType = self::TAG_MATCH_TYPE_CONTAINS;
         }
         $includeNone = in_array(self::NONE_VALUE, $tagIds, true);
         $tagIds = array_values(array_filter($tagIds, fn (string $id): bool => $id !== self::NONE_VALUE));
@@ -227,7 +227,7 @@ class TimeEntryFilter
             }
         };
 
-        if ($tagFilter === self::TAG_FILTER_NOT_CONTAINS) {
+        if ($tagMatchType === self::TAG_MATCH_TYPE_NOT_CONTAINS) {
             $this->builder->where(function (Builder $builder) use ($tagCondition, $includeNone): void {
                 $builder->whereNot($tagCondition);
                 if (! $includeNone) {

--- a/e2e/reporting-tag-match.spec.ts
+++ b/e2e/reporting-tag-match.spec.ts
@@ -1,0 +1,69 @@
+import { expect } from '@playwright/test';
+import { test } from '../playwright/fixtures';
+import { goToReportingDetailed, waitForDetailedReportingUpdate } from './utils/reporting';
+import { createTimeEntryWithTagViaApi } from './utils/api';
+
+// Each test registers a new user and creates test data via the API
+test.describe.configure({ timeout: 30000 });
+
+test('detailed reporting: "Does Not Contain" excludes entries with the selected tag', async ({
+    page,
+    ctx,
+}) => {
+    const tagA = 'MatchTagA ' + Math.floor(Math.random() * 10000);
+    const tagB = 'MatchTagB ' + Math.floor(Math.random() * 10000);
+    await createTimeEntryWithTagViaApi(ctx, tagA, '1h');
+    await createTimeEntryWithTagViaApi(ctx, tagB, '2h');
+
+    await goToReportingDetailed(page);
+    await expect(page.getByText(`Entry with tag ${tagA}`).first()).toBeVisible();
+    await expect(page.getByText(`Entry with tag ${tagB}`).first()).toBeVisible();
+
+    // Open the Tags dropdown, select tagA, then switch the match mode to "Does Not Contain"
+    await page.getByRole('button', { name: 'Tags' }).click();
+    await Promise.all([
+        waitForDetailedReportingUpdate(page),
+        page.getByRole('option').filter({ hasText: tagA }).click(),
+    ]);
+    await Promise.all([
+        waitForDetailedReportingUpdate(page),
+        page.getByRole('radio', { name: 'Does Not Contain', exact: true }).click(),
+    ]);
+    await page.keyboard.press('Escape');
+
+    // The entry with tagA is excluded; the entry with tagB remains
+    await expect(page.getByText(`Entry with tag ${tagA}`)).toHaveCount(0);
+    await expect(page.getByText(`Entry with tag ${tagB}`).first()).toBeVisible();
+});
+
+test('detailed reporting: toggling between "Contains" and "Does Not Contain" flips the result', async ({
+    page,
+    ctx,
+}) => {
+    const tagA = 'ToggleTagA ' + Math.floor(Math.random() * 10000);
+    const tagB = 'ToggleTagB ' + Math.floor(Math.random() * 10000);
+    await createTimeEntryWithTagViaApi(ctx, tagA, '1h');
+    await createTimeEntryWithTagViaApi(ctx, tagB, '2h');
+
+    await goToReportingDetailed(page);
+    await page.getByRole('button', { name: 'Tags' }).click();
+    await Promise.all([
+        waitForDetailedReportingUpdate(page),
+        page.getByRole('option').filter({ hasText: tagA }).click(),
+    ]);
+
+    // "Contains" tagA -> only the tagA entry is listed
+    await page.keyboard.press('Escape');
+    await expect(page.getByText(`Entry with tag ${tagA}`).first()).toBeVisible();
+    await expect(page.getByText(`Entry with tag ${tagB}`)).toHaveCount(0);
+
+    // "Does Not Contain" tagA -> flips to the tagB entry
+    await page.getByRole('button', { name: 'Tags' }).click();
+    await Promise.all([
+        waitForDetailedReportingUpdate(page),
+        page.getByRole('radio', { name: 'Does Not Contain', exact: true }).click(),
+    ]);
+    await page.keyboard.press('Escape');
+    await expect(page.getByText(`Entry with tag ${tagB}`).first()).toBeVisible();
+    await expect(page.getByText(`Entry with tag ${tagA}`)).toHaveCount(0);
+});

--- a/resources/js/Components/Common/Reporting/ReportingFilterBar.vue
+++ b/resources/js/Components/Common/Reporting/ReportingFilterBar.vue
@@ -2,12 +2,7 @@
 import { CheckCircleIcon, TagIcon, UserGroupIcon } from '@heroicons/vue/20/solid';
 import { FolderIcon } from '@heroicons/vue/16/solid';
 import { Check } from '@lucide/vue';
-import {
-    RadioGroupIndicator,
-    RadioGroupItem,
-    RadioGroupRoot,
-    type AcceptableValue,
-} from 'reka-ui';
+import { RadioGroupIndicator, RadioGroupItem, RadioGroupRoot, type AcceptableValue } from 'reka-ui';
 import BillableIcon from '@/packages/ui/src/Icons/BillableIcon.vue';
 import ReportingRoundingControls from '@/Components/Common/Reporting/ReportingRoundingControls.vue';
 import TaskMultiselectDropdown from '@/Components/Common/Task/TaskMultiselectDropdown.vue';

--- a/resources/js/Components/Common/Reporting/ReportingFilterBar.vue
+++ b/resources/js/Components/Common/Reporting/ReportingFilterBar.vue
@@ -1,6 +1,13 @@
 <script setup lang="ts">
 import { CheckCircleIcon, TagIcon, UserGroupIcon } from '@heroicons/vue/20/solid';
 import { FolderIcon } from '@heroicons/vue/16/solid';
+import { Check } from '@lucide/vue';
+import {
+    RadioGroupIndicator,
+    RadioGroupItem,
+    RadioGroupRoot,
+    type AcceptableValue,
+} from 'reka-ui';
 import BillableIcon from '@/packages/ui/src/Icons/BillableIcon.vue';
 import ReportingRoundingControls from '@/Components/Common/Reporting/ReportingRoundingControls.vue';
 import TaskMultiselectDropdown from '@/Components/Common/Task/TaskMultiselectDropdown.vue';
@@ -36,6 +43,16 @@ const emit = defineEmits<{
 }>();
 
 const { tags } = useTagsQuery();
+
+const tagMatchOptions: { value: TagMatchType; label: string }[] = [
+    { value: 'contains', label: 'Contains' },
+    { value: 'not_contains', label: 'Does Not Contain' },
+];
+
+function selectTagMatchType(value: AcceptableValue) {
+    tagMatchType.value = value as TagMatchType;
+    emit('submit');
+}
 
 async function createTag(name: string) {
     return await useTagsStore().createTag(name);
@@ -98,39 +115,29 @@ async function createTag(name: string) {
                     <template #content-before-list>
                         <div class="mt-2 border-b border-card-background-separator pb-2">
                             <div
+                                id="tag-match-type-label"
                                 class="mb-1.5 px-2 text-xs font-medium text-text-tertiary uppercase">
                                 Match
                             </div>
-                            <div class="space-y-1">
-                                <button
-                                    type="button"
-                                    class="w-full rounded-md px-2 py-1.5 text-left text-sm font-medium"
-                                    :class="
-                                        tagMatchType === 'contains'
-                                            ? 'bg-card-background-active text-text-primary'
-                                            : 'text-text-secondary hover:bg-card-background-active'
-                                    "
-                                    @click="
-                                        tagMatchType = 'contains';
-                                        emit('submit');
-                                    ">
-                                    Contains
-                                </button>
-                                <button
-                                    type="button"
-                                    class="w-full rounded-md px-2 py-1.5 text-left text-sm font-medium"
-                                    :class="
-                                        tagMatchType === 'not_contains'
-                                            ? 'bg-card-background-active text-text-primary'
-                                            : 'text-text-secondary hover:bg-card-background-active'
-                                    "
-                                    @click="
-                                        tagMatchType = 'not_contains';
-                                        emit('submit');
-                                    ">
-                                    Does Not Contain
-                                </button>
-                            </div>
+                            <RadioGroupRoot
+                                :model-value="tagMatchType"
+                                aria-labelledby="tag-match-type-label"
+                                class="space-y-1"
+                                @update:model-value="selectTagMatchType">
+                                <RadioGroupItem
+                                    v-for="option in tagMatchOptions"
+                                    :key="option.value"
+                                    :value="option.value"
+                                    class="relative flex w-full items-center rounded-md py-1.5 pl-2 pr-8 text-left text-sm font-medium text-text-secondary hover:bg-card-background-active data-[state=checked]:text-text-primary">
+                                    {{ option.label }}
+                                    <span
+                                        class="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+                                        <RadioGroupIndicator>
+                                            <Check class="h-4 w-4" />
+                                        </RadioGroupIndicator>
+                                    </span>
+                                </RadioGroupItem>
+                            </RadioGroupRoot>
                         </div>
                     </template>
                 </TagDropdown>

--- a/resources/js/Components/Common/Reporting/ReportingFilterBar.vue
+++ b/resources/js/Components/Common/Reporting/ReportingFilterBar.vue
@@ -14,7 +14,7 @@ import DateRangePicker from '@/packages/ui/src/Input/DateRangePicker.vue';
 import TagDropdown from '@/packages/ui/src/Tag/TagDropdown.vue';
 import { useTagsQuery } from '@/utils/useTagsQuery';
 import { useTagsStore } from '@/utils/useTags';
-import type { TagFilter } from '@/types/reporting';
+import type { TagMatchType } from '@/types/reporting';
 
 type TimeEntryRoundingType = 'up' | 'down' | 'nearest';
 
@@ -23,7 +23,7 @@ const selectedProjects = defineModel<string[]>('selectedProjects', { required: t
 const selectedTasks = defineModel<string[]>('selectedTasks', { required: true });
 const selectedClients = defineModel<string[]>('selectedClients', { required: true });
 const selectedTags = defineModel<string[]>('selectedTags', { required: true });
-const tagFilter = defineModel<TagFilter>('tagFilter', { required: true });
+const tagMatchType = defineModel<TagMatchType>('tagMatchType', { required: true });
 const billable = defineModel<'true' | 'false' | null>('billable', { required: true });
 const roundingEnabled = defineModel<boolean>('roundingEnabled', { required: true });
 const roundingType = defineModel<TimeEntryRoundingType>('roundingType', { required: true });
@@ -106,12 +106,12 @@ async function createTag(name: string) {
                                     type="button"
                                     class="w-full rounded-md px-2 py-1.5 text-left text-sm font-medium"
                                     :class="
-                                        tagFilter === 'contains'
+                                        tagMatchType === 'contains'
                                             ? 'bg-card-background-active text-text-primary'
                                             : 'text-text-secondary hover:bg-card-background-active'
                                     "
                                     @click="
-                                        tagFilter = 'contains';
+                                        tagMatchType = 'contains';
                                         emit('submit');
                                     ">
                                     Contains
@@ -120,12 +120,12 @@ async function createTag(name: string) {
                                     type="button"
                                     class="w-full rounded-md px-2 py-1.5 text-left text-sm font-medium"
                                     :class="
-                                        tagFilter === 'not_contains'
+                                        tagMatchType === 'not_contains'
                                             ? 'bg-card-background-active text-text-primary'
                                             : 'text-text-secondary hover:bg-card-background-active'
                                     "
                                     @click="
-                                        tagFilter = 'not_contains';
+                                        tagMatchType = 'not_contains';
                                         emit('submit');
                                     ">
                                     Does Not Contain

--- a/resources/js/Components/Common/Reporting/ReportingFilterBar.vue
+++ b/resources/js/Components/Common/Reporting/ReportingFilterBar.vue
@@ -14,6 +14,7 @@ import DateRangePicker from '@/packages/ui/src/Input/DateRangePicker.vue';
 import TagDropdown from '@/packages/ui/src/Tag/TagDropdown.vue';
 import { useTagsQuery } from '@/utils/useTagsQuery';
 import { useTagsStore } from '@/utils/useTags';
+import type { TagFilter } from '@/types/reporting';
 
 type TimeEntryRoundingType = 'up' | 'down' | 'nearest';
 
@@ -22,6 +23,7 @@ const selectedProjects = defineModel<string[]>('selectedProjects', { required: t
 const selectedTasks = defineModel<string[]>('selectedTasks', { required: true });
 const selectedClients = defineModel<string[]>('selectedClients', { required: true });
 const selectedTags = defineModel<string[]>('selectedTags', { required: true });
+const tagFilter = defineModel<TagFilter>('tagFilter', { required: true });
 const billable = defineModel<'true' | 'false' | null>('billable', { required: true });
 const roundingEnabled = defineModel<boolean>('roundingEnabled', { required: true });
 const roundingType = defineModel<TimeEntryRoundingType>('roundingType', { required: true });
@@ -92,6 +94,44 @@ async function createTag(name: string) {
                             :active="selectedTags.length > 0"
                             title="Tags"
                             :icon="TagIcon" />
+                    </template>
+                    <template #content-before-list>
+                        <div class="mt-2 border-b border-card-background-separator pb-2">
+                            <div
+                                class="mb-1.5 px-2 text-xs font-medium text-text-tertiary uppercase">
+                                Match
+                            </div>
+                            <div class="space-y-1">
+                                <button
+                                    type="button"
+                                    class="w-full rounded-md px-2 py-1.5 text-left text-sm font-medium"
+                                    :class="
+                                        tagFilter === 'contains'
+                                            ? 'bg-card-background-active text-text-primary'
+                                            : 'text-text-secondary hover:bg-card-background-active'
+                                    "
+                                    @click="
+                                        tagFilter = 'contains';
+                                        emit('submit');
+                                    ">
+                                    Contains
+                                </button>
+                                <button
+                                    type="button"
+                                    class="w-full rounded-md px-2 py-1.5 text-left text-sm font-medium"
+                                    :class="
+                                        tagFilter === 'not_contains'
+                                            ? 'bg-card-background-active text-text-primary'
+                                            : 'text-text-secondary hover:bg-card-background-active'
+                                    "
+                                    @click="
+                                        tagFilter = 'not_contains';
+                                        emit('submit');
+                                    ">
+                                    Does Not Contain
+                                </button>
+                            </div>
+                        </div>
                     </template>
                 </TagDropdown>
 

--- a/resources/js/Components/Common/Reporting/ReportingOverview.vue
+++ b/resources/js/Components/Common/Reporting/ReportingOverview.vue
@@ -49,6 +49,7 @@ import type { ExportFormat } from '@/types/reporting';
 import { getRandomColorWithSeed } from '@/packages/ui/src/utils/color';
 import { useProjectsQuery } from '@/utils/useProjectsQuery';
 import { useAggregatedTimeEntriesQuery } from '@/utils/useAggregatedTimeEntriesQuery';
+import type { TagFilter } from '@/types/reporting';
 
 type TimeEntryRoundingType = 'up' | 'down' | 'nearest';
 
@@ -67,6 +68,7 @@ const selectedProjects = ref<string[]>([]);
 const selectedMembers = ref<string[]>([]);
 const selectedTasks = ref<string[]>([]);
 const selectedClients = ref<string[]>([]);
+const tagFilter = ref<TagFilter>('contains');
 
 const billable = ref<'true' | 'false' | null>(null);
 const roundingEnabled = ref<boolean>(false);
@@ -122,6 +124,7 @@ const filterParams = computed<AggregatedTimeEntriesQueryParams>(() => {
         task_ids: selectedTasks.value.length > 0 ? selectedTasks.value : undefined,
         client_ids: selectedClients.value.length > 0 ? selectedClients.value : undefined,
         tag_ids: selectedTags.value.length > 0 ? selectedTags.value : undefined,
+        tag_filter: selectedTags.value.length > 0 ? tagFilter.value : undefined,
         billable: billable.value !== null ? billable.value : undefined,
         member_id: getCurrentRole() === 'employee' ? getCurrentMembershipId() : undefined,
         rounding_type: roundingEnabled.value ? roundingType.value : undefined,
@@ -366,6 +369,7 @@ const tableData = computed(() => {
         v-model:selected-tasks="selectedTasks"
         v-model:selected-clients="selectedClients"
         v-model:selected-tags="selectedTags"
+        v-model:tag-filter="tagFilter"
         v-model:billable="billable"
         v-model:rounding-enabled="roundingEnabled"
         v-model:rounding-type="roundingType"

--- a/resources/js/Components/Common/Reporting/ReportingOverview.vue
+++ b/resources/js/Components/Common/Reporting/ReportingOverview.vue
@@ -49,7 +49,7 @@ import type { ExportFormat } from '@/types/reporting';
 import { getRandomColorWithSeed } from '@/packages/ui/src/utils/color';
 import { useProjectsQuery } from '@/utils/useProjectsQuery';
 import { useAggregatedTimeEntriesQuery } from '@/utils/useAggregatedTimeEntriesQuery';
-import type { TagFilter } from '@/types/reporting';
+import type { TagMatchType } from '@/types/reporting';
 
 type TimeEntryRoundingType = 'up' | 'down' | 'nearest';
 
@@ -68,7 +68,7 @@ const selectedProjects = ref<string[]>([]);
 const selectedMembers = ref<string[]>([]);
 const selectedTasks = ref<string[]>([]);
 const selectedClients = ref<string[]>([]);
-const tagFilter = ref<TagFilter>('contains');
+const tagMatchType = ref<TagMatchType>('contains');
 
 const billable = ref<'true' | 'false' | null>(null);
 const roundingEnabled = ref<boolean>(false);
@@ -124,7 +124,7 @@ const filterParams = computed<AggregatedTimeEntriesQueryParams>(() => {
         task_ids: selectedTasks.value.length > 0 ? selectedTasks.value : undefined,
         client_ids: selectedClients.value.length > 0 ? selectedClients.value : undefined,
         tag_ids: selectedTags.value.length > 0 ? selectedTags.value : undefined,
-        tag_filter: selectedTags.value.length > 0 ? tagFilter.value : undefined,
+        tag_match_type: selectedTags.value.length > 0 ? tagMatchType.value : undefined,
         billable: billable.value !== null ? billable.value : undefined,
         member_id: getCurrentRole() === 'employee' ? getCurrentMembershipId() : undefined,
         rounding_type: roundingEnabled.value ? roundingType.value : undefined,
@@ -369,7 +369,7 @@ const tableData = computed(() => {
         v-model:selected-tasks="selectedTasks"
         v-model:selected-clients="selectedClients"
         v-model:selected-tags="selectedTags"
-        v-model:tag-filter="tagFilter"
+        v-model:tag-match-type="tagMatchType"
         v-model:billable="billable"
         v-model:rounding-enabled="roundingEnabled"
         v-model:rounding-type="roundingType"

--- a/resources/js/Pages/ReportingDetailed.vue
+++ b/resources/js/Pages/ReportingDetailed.vue
@@ -67,7 +67,7 @@ import ReportingFilterBar from '@/Components/Common/Reporting/ReportingFilterBar
 import { useTimeEntriesReportQuery } from '@/utils/useTimeEntriesReportQuery';
 import { useTimeEntriesMutations } from '@/utils/useTimeEntriesMutations';
 import { useOrganizationQuery } from '@/utils/useOrganizationQuery';
-import type { TagFilter } from '@/types/reporting';
+import type { TagMatchType } from '@/types/reporting';
 
 // TimeEntryRoundingType is now defined in ReportingRoundingControls component
 type TimeEntryRoundingType = 'up' | 'down' | 'nearest';
@@ -85,7 +85,7 @@ const selectedProjects = ref<string[]>([]);
 const selectedMembers = ref<string[]>([]);
 const selectedTasks = ref<string[]>([]);
 const selectedClients = ref<string[]>([]);
-const tagFilter = ref<TagFilter>('contains');
+const tagMatchType = ref<TagMatchType>('contains');
 const billable = ref<'true' | 'false' | null>(null);
 const roundingEnabled = ref<boolean>(false);
 const roundingType = ref<TimeEntryRoundingType>('nearest');
@@ -117,7 +117,7 @@ function getFilterAttributes() {
         task_ids: selectedTasks.value.length > 0 ? selectedTasks.value : undefined,
         client_ids: selectedClients.value.length > 0 ? selectedClients.value : undefined,
         tag_ids: selectedTags.value.length > 0 ? selectedTags.value : undefined,
-        tag_filter: selectedTags.value.length > 0 ? tagFilter.value : undefined,
+        tag_match_type: selectedTags.value.length > 0 ? tagMatchType.value : undefined,
         billable: billable.value !== null ? billable.value : undefined,
         rounding_type: roundingEnabled.value ? roundingType.value : undefined,
         rounding_minutes: roundingEnabled.value ? roundingMinutes.value : undefined,
@@ -340,7 +340,7 @@ async function downloadExport(format: ExportFormat) {
             v-model:selected-tasks="selectedTasks"
             v-model:selected-clients="selectedClients"
             v-model:selected-tags="selectedTags"
-            v-model:tag-filter="tagFilter"
+            v-model:tag-match-type="tagMatchType"
             v-model:billable="billable"
             v-model:rounding-enabled="roundingEnabled"
             v-model:rounding-type="roundingType"

--- a/resources/js/Pages/ReportingDetailed.vue
+++ b/resources/js/Pages/ReportingDetailed.vue
@@ -67,6 +67,7 @@ import ReportingFilterBar from '@/Components/Common/Reporting/ReportingFilterBar
 import { useTimeEntriesReportQuery } from '@/utils/useTimeEntriesReportQuery';
 import { useTimeEntriesMutations } from '@/utils/useTimeEntriesMutations';
 import { useOrganizationQuery } from '@/utils/useOrganizationQuery';
+import type { TagFilter } from '@/types/reporting';
 
 // TimeEntryRoundingType is now defined in ReportingRoundingControls component
 type TimeEntryRoundingType = 'up' | 'down' | 'nearest';
@@ -84,6 +85,7 @@ const selectedProjects = ref<string[]>([]);
 const selectedMembers = ref<string[]>([]);
 const selectedTasks = ref<string[]>([]);
 const selectedClients = ref<string[]>([]);
+const tagFilter = ref<TagFilter>('contains');
 const billable = ref<'true' | 'false' | null>(null);
 const roundingEnabled = ref<boolean>(false);
 const roundingType = ref<TimeEntryRoundingType>('nearest');
@@ -115,6 +117,7 @@ function getFilterAttributes() {
         task_ids: selectedTasks.value.length > 0 ? selectedTasks.value : undefined,
         client_ids: selectedClients.value.length > 0 ? selectedClients.value : undefined,
         tag_ids: selectedTags.value.length > 0 ? selectedTags.value : undefined,
+        tag_filter: selectedTags.value.length > 0 ? tagFilter.value : undefined,
         billable: billable.value !== null ? billable.value : undefined,
         rounding_type: roundingEnabled.value ? roundingType.value : undefined,
         rounding_minutes: roundingEnabled.value ? roundingMinutes.value : undefined,
@@ -337,6 +340,7 @@ async function downloadExport(format: ExportFormat) {
             v-model:selected-tasks="selectedTasks"
             v-model:selected-clients="selectedClients"
             v-model:selected-tags="selectedTags"
+            v-model:tag-filter="tagFilter"
             v-model:billable="billable"
             v-model:rounding-enabled="roundingEnabled"
             v-model:rounding-type="roundingType"

--- a/resources/js/packages/api/src/openapi.json.client.ts
+++ b/resources/js/packages/api/src/openapi.json.client.ts
@@ -448,6 +448,7 @@ const ReportStoreRequest = z
                 client_ids: z.union([z.array(z.string()), z.null()]).optional(),
                 project_ids: z.union([z.array(z.string()), z.null()]).optional(),
                 tag_ids: z.union([z.array(z.string()), z.null()]).optional(),
+                tag_filter: z.enum(['contains', 'not_contains']).optional(),
                 task_ids: z.union([z.array(z.string()), z.null()]).optional(),
                 group: TimeEntryAggregationType,
                 sub_group: TimeEntryAggregationType,
@@ -481,6 +482,7 @@ const DetailedReportResource = z
                 client_ids: z.union([z.array(z.string()), z.null()]),
                 project_ids: z.union([z.array(z.string()), z.null()]),
                 tag_ids: z.union([z.array(z.string()), z.null()]),
+                tag_filter: z.union([z.enum(['contains', 'not_contains']), z.null()]),
                 task_ids: z.union([z.array(z.string()), z.null()]),
                 rounding_type: z.union([z.string(), z.null()]),
                 rounding_minutes: z.union([z.number(), z.null()]),
@@ -3785,6 +3787,11 @@ Users with the permission &#x60;time-entries:view:own&#x60; can only use this en
                 schema: z.array(z.string()).min(1).optional(),
             },
             {
+                name: 'tag_filter',
+                type: 'Query',
+                schema: z.enum(['contains', 'not_contains']).optional(),
+            },
+            {
                 name: 'task_ids',
                 type: 'Query',
                 schema: z.array(z.string()).min(1).optional(),
@@ -4166,6 +4173,11 @@ If the group parameters are all set to &#x60;null&#x60; or are all missing, the 
                 schema: z.array(z.string()).min(1).optional(),
             },
             {
+                name: 'tag_filter',
+                type: 'Query',
+                schema: z.enum(['contains', 'not_contains']).optional(),
+            },
+            {
                 name: 'task_ids',
                 type: 'Query',
                 schema: z.array(z.string()).min(1).optional(),
@@ -4360,6 +4372,11 @@ If the group parameters are all set to &#x60;null&#x60; or are all missing, the 
                 schema: z.array(z.string()).min(1).optional(),
             },
             {
+                name: 'tag_filter',
+                type: 'Query',
+                schema: z.enum(['contains', 'not_contains']).optional(),
+            },
+            {
                 name: 'task_ids',
                 type: 'Query',
                 schema: z.array(z.string()).min(1).optional(),
@@ -4486,6 +4503,11 @@ If the group parameters are all set to &#x60;null&#x60; or are all missing, the 
                 name: 'tag_ids',
                 type: 'Query',
                 schema: z.array(z.string()).min(1).optional(),
+            },
+            {
+                name: 'tag_filter',
+                type: 'Query',
+                schema: z.enum(['contains', 'not_contains']).optional(),
             },
             {
                 name: 'task_ids',

--- a/resources/js/packages/api/src/openapi.json.client.ts
+++ b/resources/js/packages/api/src/openapi.json.client.ts
@@ -448,7 +448,7 @@ const ReportStoreRequest = z
                 client_ids: z.union([z.array(z.string()), z.null()]).optional(),
                 project_ids: z.union([z.array(z.string()), z.null()]).optional(),
                 tag_ids: z.union([z.array(z.string()), z.null()]).optional(),
-                tag_filter: z.enum(['contains', 'not_contains']).optional(),
+                tag_match_type: z.enum(['contains', 'not_contains']).optional(),
                 task_ids: z.union([z.array(z.string()), z.null()]).optional(),
                 group: TimeEntryAggregationType,
                 sub_group: TimeEntryAggregationType,
@@ -482,7 +482,7 @@ const DetailedReportResource = z
                 client_ids: z.union([z.array(z.string()), z.null()]),
                 project_ids: z.union([z.array(z.string()), z.null()]),
                 tag_ids: z.union([z.array(z.string()), z.null()]),
-                tag_filter: z.union([z.enum(['contains', 'not_contains']), z.null()]),
+                tag_match_type: z.union([z.enum(['contains', 'not_contains']), z.null()]),
                 task_ids: z.union([z.array(z.string()), z.null()]),
                 rounding_type: z.union([z.string(), z.null()]),
                 rounding_minutes: z.union([z.number(), z.null()]),
@@ -3787,7 +3787,7 @@ Users with the permission &#x60;time-entries:view:own&#x60; can only use this en
                 schema: z.array(z.string()).min(1).optional(),
             },
             {
-                name: 'tag_filter',
+                name: 'tag_match_type',
                 type: 'Query',
                 schema: z.enum(['contains', 'not_contains']).optional(),
             },
@@ -4173,7 +4173,7 @@ If the group parameters are all set to &#x60;null&#x60; or are all missing, the 
                 schema: z.array(z.string()).min(1).optional(),
             },
             {
-                name: 'tag_filter',
+                name: 'tag_match_type',
                 type: 'Query',
                 schema: z.enum(['contains', 'not_contains']).optional(),
             },
@@ -4372,7 +4372,7 @@ If the group parameters are all set to &#x60;null&#x60; or are all missing, the 
                 schema: z.array(z.string()).min(1).optional(),
             },
             {
-                name: 'tag_filter',
+                name: 'tag_match_type',
                 type: 'Query',
                 schema: z.enum(['contains', 'not_contains']).optional(),
             },
@@ -4505,7 +4505,7 @@ If the group parameters are all set to &#x60;null&#x60; or are all missing, the 
                 schema: z.array(z.string()).min(1).optional(),
             },
             {
-                name: 'tag_filter',
+                name: 'tag_match_type',
                 type: 'Query',
                 schema: z.enum(['contains', 'not_contains']).optional(),
             },

--- a/resources/js/packages/ui/src/Tag/TagDropdown.vue
+++ b/resources/js/packages/ui/src/Tag/TagDropdown.vue
@@ -114,6 +114,7 @@ const showCreateTagModal = ref(false);
                         class="w-full rounded-md border border-input-border bg-input-background px-3 py-1.5 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none"
                         placeholder="Search for a Tag..." />
                 </ComboboxAnchor>
+                <slot name="content-before-list"></slot>
                 <ComboboxContent
                     :dismiss-able="false"
                     position="inline"

--- a/resources/js/types/reporting.ts
+++ b/resources/js/types/reporting.ts
@@ -1,1 +1,2 @@
 export type ExportFormat = 'xlsx' | 'csv' | 'ods' | 'pdf';
+export type TagFilter = 'contains' | 'not_contains';

--- a/resources/js/types/reporting.ts
+++ b/resources/js/types/reporting.ts
@@ -1,2 +1,2 @@
 export type ExportFormat = 'xlsx' | 'csv' | 'ods' | 'pdf';
-export type TagFilter = 'contains' | 'not_contains';
+export type TagMatchType = 'contains' | 'not_contains';

--- a/tests/Unit/Endpoint/Api/V1/Public/PublicReportEndpointTest.php
+++ b/tests/Unit/Endpoint/Api/V1/Public/PublicReportEndpointTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Endpoint\Api\V1\Public;
 
+use App\Enums\TagMatchType;
 use App\Enums\TimeEntryAggregationType;
 use App\Enums\TimeEntryAggregationTypeInterval;
 use App\Enums\Weekday;
@@ -663,6 +664,60 @@ class PublicReportEndpointTest extends ApiEndpointTestAbstract
             'data' => [
                 'seconds' => 200,
                 'cost' => 0,
+                'grouped_type' => TimeEntryAggregationType::Project->value,
+            ],
+        ]);
+    }
+
+    public function test_show_applies_not_contains_tag_match_type(): void
+    {
+        // Arrange
+        $organization = Organization::factory()->create();
+        $tagA = Tag::factory()->forOrganization($organization)->create();
+        $tagB = Tag::factory()->forOrganization($organization)->create();
+
+        // Entry with tagA (should be excluded by "does not contain tagA")
+        TimeEntry::factory()->forOrganization($organization)
+            ->startWithDuration(now()->subDay(), 100)
+            ->create([
+                'tags' => [$tagA->getKey()],
+            ]);
+        // Entry with a different tag (should be included)
+        TimeEntry::factory()->forOrganization($organization)
+            ->startWithDuration(now()->subDay(), 200)
+            ->create([
+                'tags' => [$tagB->getKey()],
+            ]);
+        // Entry without tags (should be included)
+        TimeEntry::factory()->forOrganization($organization)
+            ->startWithDuration(now()->subDay(), 50)
+            ->create();
+
+        $reportDto = new ReportPropertiesDto;
+        $reportDto->start = now()->subDays(2);
+        $reportDto->end = now();
+        $reportDto->group = TimeEntryAggregationType::Project;
+        $reportDto->subGroup = TimeEntryAggregationType::Task;
+        $reportDto->historyGroup = TimeEntryAggregationTypeInterval::Day;
+        $reportDto->weekStart = Weekday::Monday;
+        $reportDto->timezone = 'Europe/Vienna';
+        $reportDto->setTagIds([$tagA->getKey()]);
+        $reportDto->setTagMatchType(TagMatchType::NotContains);
+        $report = Report::factory()->forOrganization($organization)->public()->create([
+            'public_until' => null,
+            'properties' => $reportDto,
+        ]);
+
+        // Act
+        $response = $this->getJson(route('api.v1.public.reports.show'), [
+            'X-Api-Key' => $report->share_secret,
+        ]);
+
+        // Assert: tagA entry (100s) excluded; tagB (200s) + untagged (50s) included
+        $response->assertOk();
+        $response->assertJson([
+            'data' => [
+                'seconds' => 250,
                 'grouped_type' => TimeEntryAggregationType::Project->value,
             ],
         ]);

--- a/tests/Unit/Endpoint/Api/V1/ReportEndpointTest.php
+++ b/tests/Unit/Endpoint/Api/V1/ReportEndpointTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Endpoint\Api\V1;
 
+use App\Enums\TagMatchType;
 use App\Enums\TimeEntryAggregationType;
 use App\Enums\TimeEntryRoundingType;
 use App\Enums\Weekday;
@@ -684,5 +685,65 @@ class ReportEndpointTest extends ApiEndpointTestAbstract
         $this->assertDatabaseMissing(Report::class, [
             'id' => $report->getKey(),
         ]);
+    }
+
+    public function test_store_endpoint_persists_tag_match_type(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'reports:create',
+        ]);
+        $tag = Tag::factory()->forOrganization($data->organization)->create();
+        Passport::actingAs($data->user);
+
+        // Act
+        $response = $this->withoutExceptionHandling()->postJson(route('api.v1.reports.store', [$data->organization->getKey()]), [
+            'name' => 'Report with tag match type',
+            'is_public' => false,
+            'properties' => [
+                'start' => Carbon::now()->subDays(30)->toIso8601ZuluString(),
+                'end' => Carbon::now()->toIso8601ZuluString(),
+                'group' => TimeEntryAggregationType::Project->value,
+                'sub_group' => TimeEntryAggregationType::Task->value,
+                'history_group' => TimeEntryAggregationType::Day->value,
+                'tag_ids' => [$tag->getKey()],
+                'tag_match_type' => TagMatchType::NotContains->value,
+            ],
+        ]);
+
+        // Assert
+        $response->assertStatus(201);
+        /** @var Report $report */
+        $report = Report::query()->findOrFail($response->json('data.id'));
+        $this->assertSame(TagMatchType::NotContains, $report->properties->tagMatchType);
+        // DetailedReportResource exposes the match type in the response
+        $response->assertJsonPath('data.properties.tag_match_type', TagMatchType::NotContains->value);
+    }
+
+    public function test_store_endpoint_rejects_invalid_tag_match_type(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'reports:create',
+        ]);
+        Passport::actingAs($data->user);
+
+        // Act
+        $response = $this->postJson(route('api.v1.reports.store', [$data->organization->getKey()]), [
+            'name' => 'Report with invalid tag match type',
+            'is_public' => false,
+            'properties' => [
+                'start' => Carbon::now()->subDays(30)->toIso8601ZuluString(),
+                'end' => Carbon::now()->toIso8601ZuluString(),
+                'group' => TimeEntryAggregationType::Project->value,
+                'sub_group' => TimeEntryAggregationType::Task->value,
+                'history_group' => TimeEntryAggregationType::Day->value,
+                'tag_match_type' => 'invalid_value',
+            ],
+        ]);
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertInvalid(['properties.tag_match_type']);
     }
 }

--- a/tests/Unit/Endpoint/Api/V1/TimeEntryEndpointTest.php
+++ b/tests/Unit/Endpoint/Api/V1/TimeEntryEndpointTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Endpoint\Api\V1;
 
 use App\Enums\ExportFormat;
 use App\Enums\Role;
+use App\Enums\TagMatchType;
 use App\Enums\TimeEntryAggregationType;
 use App\Enums\TimeEntryAggregationTypeInterval;
 use App\Enums\TimeEntryRoundingType;
@@ -4350,5 +4351,154 @@ class TimeEntryEndpointTest extends ApiEndpointTestAbstract
         $this->assertResponseCode($response, 200);
         $response->assertJsonCount(1, 'data');
         $response->assertJsonPath('data.0.id', $timeEntryWithoutTag->getKey());
+    }
+
+    public function test_index_endpoint_with_not_contains_tag_match_type_excludes_entries_with_tag(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'time-entries:view:all',
+        ]);
+        $tag = Tag::factory()->forOrganization($data->organization)->create();
+        $timeEntryWithTag = TimeEntry::factory()
+            ->forOrganization($data->organization)
+            ->forMember($data->member)
+            ->create([
+                'start' => Carbon::now()->subHour(),
+                'tags' => [$tag->getKey()],
+            ]);
+        $timeEntryWithEmptyTags = TimeEntry::factory()
+            ->forOrganization($data->organization)
+            ->forMember($data->member)
+            ->create([
+                'start' => Carbon::now()->subHour(),
+                'tags' => [],
+            ]);
+        $timeEntryWithNullTags = TimeEntry::factory()
+            ->forOrganization($data->organization)
+            ->forMember($data->member)
+            ->create([
+                'start' => Carbon::now()->subHour(),
+                'tags' => null,
+            ]);
+        Passport::actingAs($data->user);
+
+        // Act
+        $response = $this->getJson(route('api.v1.time-entries.index', [
+            $data->organization->getKey(),
+            'tag_ids' => [$tag->getKey()],
+            'tag_match_type' => TagMatchType::NotContains->value,
+            'start' => Carbon::now()->subDay()->toIso8601ZuluString(),
+            'end' => Carbon::now()->addDay()->toIso8601ZuluString(),
+        ]));
+
+        // Assert: the tagged entry is excluded; the untagged (empty + null) entries remain
+        $response->assertValid();
+        $this->assertResponseCode($response, 200);
+        $response->assertJsonCount(2, 'data');
+        $returnedIds = collect($response->json('data'))->pluck('id');
+        $this->assertTrue($returnedIds->contains($timeEntryWithEmptyTags->getKey()));
+        $this->assertTrue($returnedIds->contains($timeEntryWithNullTags->getKey()));
+        $this->assertFalse($returnedIds->contains($timeEntryWithTag->getKey()));
+    }
+
+    public function test_index_endpoint_with_contains_tag_match_type_returns_only_entries_with_tag(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'time-entries:view:all',
+        ]);
+        $tag = Tag::factory()->forOrganization($data->organization)->create();
+        $timeEntryWithTag = TimeEntry::factory()
+            ->forOrganization($data->organization)
+            ->forMember($data->member)
+            ->create([
+                'start' => Carbon::now()->subHour(),
+                'tags' => [$tag->getKey()],
+            ]);
+        TimeEntry::factory()
+            ->forOrganization($data->organization)
+            ->forMember($data->member)
+            ->create([
+                'start' => Carbon::now()->subHour(),
+                'tags' => [],
+            ]);
+        Passport::actingAs($data->user);
+
+        // Act
+        $response = $this->getJson(route('api.v1.time-entries.index', [
+            $data->organization->getKey(),
+            'tag_ids' => [$tag->getKey()],
+            'tag_match_type' => TagMatchType::Contains->value,
+            'start' => Carbon::now()->subDay()->toIso8601ZuluString(),
+            'end' => Carbon::now()->addDay()->toIso8601ZuluString(),
+        ]));
+
+        // Assert: only the entry that has the tag
+        $response->assertValid();
+        $this->assertResponseCode($response, 200);
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.id', $timeEntryWithTag->getKey());
+    }
+
+    public function test_index_endpoint_rejects_invalid_tag_match_type(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'time-entries:view:all',
+        ]);
+        $tag = Tag::factory()->forOrganization($data->organization)->create();
+        Passport::actingAs($data->user);
+
+        // Act
+        $response = $this->getJson(route('api.v1.time-entries.index', [
+            $data->organization->getKey(),
+            'tag_ids' => [$tag->getKey()],
+            'tag_match_type' => 'invalid_value',
+            'start' => Carbon::now()->subDay()->toIso8601ZuluString(),
+            'end' => Carbon::now()->addDay()->toIso8601ZuluString(),
+        ]));
+
+        // Assert
+        $this->assertResponseCode($response, 422);
+        $response->assertInvalid(['tag_match_type']);
+    }
+
+    public function test_aggregate_endpoint_with_not_contains_tag_match_type_excludes_entries_with_tag(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'time-entries:view:all',
+        ]);
+        $tag = Tag::factory()->forOrganization($data->organization)->create();
+        TimeEntry::factory()
+            ->forOrganization($data->organization)
+            ->forMember($data->member)
+            ->startWithDuration(Carbon::now()->subHour(), 100)
+            ->create([
+                'tags' => [$tag->getKey()],
+            ]);
+        TimeEntry::factory()
+            ->forOrganization($data->organization)
+            ->forMember($data->member)
+            ->startWithDuration(Carbon::now()->subHour(), 200)
+            ->create([
+                'tags' => [],
+            ]);
+        Passport::actingAs($data->user);
+
+        // Act
+        $response = $this->getJson(route('api.v1.time-entries.aggregate', [
+            $data->organization->getKey(),
+            'tag_ids' => [$tag->getKey()],
+            'tag_match_type' => TagMatchType::NotContains->value,
+            'start' => Carbon::now()->subDay()->toIso8601ZuluString(),
+            'end' => Carbon::now()->addDay()->toIso8601ZuluString(),
+        ]));
+
+        // Assert: only the untagged entry (200s) is aggregated
+        $response->assertValid();
+        $this->assertResponseCode($response, 200);
+        $response->assertJsonPath('data.seconds', 200);
     }
 }

--- a/tests/Unit/Service/TimeEntryFilterTest.php
+++ b/tests/Unit/Service/TimeEntryFilterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Service;
 
+use App\Enums\TagMatchType;
 use App\Models\Client;
 use App\Models\Project;
 use App\Models\Tag;
@@ -249,5 +250,189 @@ class TimeEntryFilterTest extends TestCaseWithDatabase
         $this->assertTrue($timeEntries->contains($timeEntryWithTag1));
         $this->assertTrue($timeEntries->contains($timeEntryWithNoTags));
         $this->assertFalse($timeEntries->contains($timeEntryWithTag2));
+    }
+
+    public function test_add_tag_ids_filter_not_contains_includes_entries_without_matching_tag(): void
+    {
+        // Arrange
+        $tag1 = Tag::factory()->create();
+        $tag2 = Tag::factory()->create();
+        $timeEntryWithTag1 = TimeEntry::factory()->create([
+            'tags' => [$tag1->getKey()],
+        ]);
+        $timeEntryWithTag2 = TimeEntry::factory()->create([
+            'tags' => [$tag2->getKey()],
+        ]);
+        $timeEntryWithAllTags = TimeEntry::factory()->create([
+            'tags' => [$tag1->getKey(), $tag2->getKey()],
+        ]);
+        $timeEntryWithEmptyTags = TimeEntry::factory()->create([
+            'tags' => [],
+        ]);
+        $timeEntryWithNullTags = TimeEntry::factory()->create([
+            'tags' => null,
+        ]);
+
+        $builder = TimeEntry::query();
+        $filter = new TimeEntryFilter($builder);
+
+        // Act
+        $filter->addTagIdsFilter([$tag1->getKey()], TagMatchType::NotContains);
+
+        // Assert
+        $timeEntries = $builder->get();
+        $this->assertCount(3, $timeEntries);
+        $this->assertFalse($timeEntries->contains($timeEntryWithTag1));
+        $this->assertTrue($timeEntries->contains($timeEntryWithTag2));
+        $this->assertFalse($timeEntries->contains($timeEntryWithAllTags));
+        $this->assertTrue($timeEntries->contains($timeEntryWithEmptyTags));
+        $this->assertTrue($timeEntries->contains($timeEntryWithNullTags));
+    }
+
+    public function test_add_tag_ids_filter_not_contains_with_none_excludes_entries_without_tags(): void
+    {
+        // Arrange
+        $tag = Tag::factory()->create();
+        $timeEntryWithTag = TimeEntry::factory()->create([
+            'tags' => [$tag->getKey()],
+        ]);
+        $timeEntryWithEmptyTags = TimeEntry::factory()->create([
+            'tags' => [],
+        ]);
+        $timeEntryWithNullTags = TimeEntry::factory()->create([
+            'tags' => null,
+        ]);
+
+        $builder = TimeEntry::query();
+        $filter = new TimeEntryFilter($builder);
+
+        // Act
+        $filter->addTagIdsFilter([TimeEntryFilter::NONE_VALUE], TagMatchType::NotContains);
+
+        // Assert
+        $timeEntries = $builder->get();
+        $this->assertCount(1, $timeEntries);
+        $this->assertTrue($timeEntries->contains($timeEntryWithTag));
+        $this->assertFalse($timeEntries->contains($timeEntryWithEmptyTags));
+        $this->assertFalse($timeEntries->contains($timeEntryWithNullTags));
+    }
+
+    public function test_add_tag_ids_filter_not_contains_with_multiple_tags_excludes_entries_with_any_of_them(): void
+    {
+        // Arrange
+        $tag1 = Tag::factory()->create();
+        $tag2 = Tag::factory()->create();
+        $tag3 = Tag::factory()->create();
+        $timeEntryWithTag1 = TimeEntry::factory()->create(['tags' => [$tag1->getKey()]]);
+        $timeEntryWithTag2 = TimeEntry::factory()->create(['tags' => [$tag2->getKey()]]);
+        $timeEntryWithTag3 = TimeEntry::factory()->create(['tags' => [$tag3->getKey()]]);
+        // a filtered tag (tag1) mixed with an unrelated one (tag3): still excluded
+        $timeEntryWithTag1AndTag3 = TimeEntry::factory()->create(['tags' => [$tag1->getKey(), $tag3->getKey()]]);
+        $timeEntryWithoutTags = TimeEntry::factory()->create(['tags' => null]);
+
+        $builder = TimeEntry::query();
+        $filter = new TimeEntryFilter($builder);
+
+        // Act: "does not contain tag1 or tag2" (NOT (has tag1 OR has tag2))
+        $filter->addTagIdsFilter([$tag1->getKey(), $tag2->getKey()], TagMatchType::NotContains);
+
+        // Assert: only entries that have neither tag1 nor tag2 remain
+        $timeEntries = $builder->get();
+        $this->assertCount(2, $timeEntries);
+        $this->assertFalse($timeEntries->contains($timeEntryWithTag1));
+        $this->assertFalse($timeEntries->contains($timeEntryWithTag2));
+        $this->assertTrue($timeEntries->contains($timeEntryWithTag3));
+        $this->assertFalse($timeEntries->contains($timeEntryWithTag1AndTag3));
+        $this->assertTrue($timeEntries->contains($timeEntryWithoutTags));
+    }
+
+    public function test_add_tag_ids_filter_contains_mode_returns_only_entries_with_tag(): void
+    {
+        // Arrange
+        $tag1 = Tag::factory()->create();
+        $tag2 = Tag::factory()->create();
+        $timeEntryWithTag1 = TimeEntry::factory()->create(['tags' => [$tag1->getKey()]]);
+        $timeEntryWithTag2 = TimeEntry::factory()->create(['tags' => [$tag2->getKey()]]);
+        $timeEntryWithEmptyTags = TimeEntry::factory()->create(['tags' => []]);
+        $timeEntryWithNullTags = TimeEntry::factory()->create(['tags' => null]);
+
+        $builder = TimeEntry::query();
+        $filter = new TimeEntryFilter($builder);
+
+        // Act: explicit contains mode
+        $filter->addTagIdsFilter([$tag1->getKey()], TagMatchType::Contains);
+
+        // Assert: only the entry that has tag1
+        $timeEntries = $builder->get();
+        $this->assertCount(1, $timeEntries);
+        $this->assertTrue($timeEntries->contains($timeEntryWithTag1));
+        $this->assertFalse($timeEntries->contains($timeEntryWithTag2));
+        $this->assertFalse($timeEntries->contains($timeEntryWithEmptyTags));
+        $this->assertFalse($timeEntries->contains($timeEntryWithNullTags));
+    }
+
+    public function test_add_tag_ids_filter_not_contains_with_none_and_tag_excludes_tagged_and_untagged(): void
+    {
+        // Arrange
+        $tag1 = Tag::factory()->create();
+        $tag2 = Tag::factory()->create();
+        $timeEntryWithTag1 = TimeEntry::factory()->create(['tags' => [$tag1->getKey()]]);
+        $timeEntryWithTag2 = TimeEntry::factory()->create(['tags' => [$tag2->getKey()]]);
+        $timeEntryWithBothTags = TimeEntry::factory()->create(['tags' => [$tag1->getKey(), $tag2->getKey()]]);
+        $timeEntryWithEmptyTags = TimeEntry::factory()->create(['tags' => []]);
+        $timeEntryWithNullTags = TimeEntry::factory()->create(['tags' => null]);
+
+        $builder = TimeEntry::query();
+        $filter = new TimeEntryFilter($builder);
+
+        // Act: NOT (has tag1 OR has no tags) => has at least one tag and not tag1
+        $filter->addTagIdsFilter([$tag1->getKey(), TimeEntryFilter::NONE_VALUE], TagMatchType::NotContains);
+
+        // Assert
+        $timeEntries = $builder->get();
+        $this->assertCount(1, $timeEntries);
+        $this->assertFalse($timeEntries->contains($timeEntryWithTag1));
+        $this->assertTrue($timeEntries->contains($timeEntryWithTag2));
+        $this->assertFalse($timeEntries->contains($timeEntryWithBothTags));
+        $this->assertFalse($timeEntries->contains($timeEntryWithEmptyTags));
+        $this->assertFalse($timeEntries->contains($timeEntryWithNullTags));
+    }
+
+    public function test_add_tag_ids_filter_with_empty_array_applies_no_filter(): void
+    {
+        // Arrange
+        $tag = Tag::factory()->create();
+        TimeEntry::factory()->create(['tags' => [$tag->getKey()]]);
+        TimeEntry::factory()->create(['tags' => []]);
+        TimeEntry::factory()->create(['tags' => null]);
+
+        // Act + Assert: an empty selection is no constraint in either mode
+        $builderNotContains = TimeEntry::query();
+        (new TimeEntryFilter($builderNotContains))->addTagIdsFilter([], TagMatchType::NotContains);
+        $this->assertCount(3, $builderNotContains->get());
+
+        $builderContains = TimeEntry::query();
+        (new TimeEntryFilter($builderContains))->addTagIdsFilter([], TagMatchType::Contains);
+        $this->assertCount(3, $builderContains->get());
+    }
+
+    public function test_add_tag_ids_filter_with_null_match_type_defaults_to_contains(): void
+    {
+        // Arrange
+        $tag = Tag::factory()->create();
+        $timeEntryWithTag = TimeEntry::factory()->create(['tags' => [$tag->getKey()]]);
+        $timeEntryWithoutTag = TimeEntry::factory()->create(['tags' => null]);
+
+        $builder = TimeEntry::query();
+        $filter = new TimeEntryFilter($builder);
+
+        // Act: a null match type falls back to "contains"
+        $filter->addTagIdsFilter([$tag->getKey()], null);
+
+        // Assert
+        $timeEntries = $builder->get();
+        $this->assertCount(1, $timeEntries);
+        $this->assertTrue($timeEntries->contains($timeEntryWithTag));
+        $this->assertFalse($timeEntries->contains($timeEntryWithoutTag));
     }
 }


### PR DESCRIPTION
## What does this PR do?

Adds support for excluding selected tags in reporting filters.
Basically you can now filter time entries based on whether specific tags are included or not in the time entry.

- Fixes https://github.com/solidtime-io/solidtime/discussions/928

The feature has been tested manually by me locally.
I also have run the npm run lint:fix, npm run format and  composer fix, composer analyse tests, and [discussed this briefly additionally in Discord with `onacter`](https://discord.com/channels/1233231440406122587/1233231440406122590/1519329885741387857)

They asked to add a screenshot of the feature: 
<img width="290" height="334" alt="Screenshot 2026-06-24 at 11 32 43" src="https://github.com/user-attachments/assets/73634782-be50-44ae-b539-1ee566635293" />

I also confirm the feature works with shared and exported reports.

There are no unit tests written for this, `onacter` mentioned they could do so, which I gladly appreciate.

## Checklist (DO NOT REMOVE)

- [x] I read the [contributing guide](https://github.com/solidtime-io/solidtime/blob/main/CONTRIBUTING.md)
- [x] I signed the [Contributor License Agreement](https://cla-assistant.io/solidtime-io/solidtime).
- [x] I commented my code, particularly in hard-to-understand areas
