### PR TITLE
fix: prevent repeated select-all behavior in TimePickerSimple to allo…

### DIFF
--- a/resources/js/packages/ui/src/Input/TimePickerSimple.vue
+++ b/resources/js/packages/ui/src/Input/TimePickerSimple.vue
@@ -91,6 +91,47 @@ const emit = defineEmits(['changed']);
 useFocus(timeInput, { initialValue: props.focus });
 
 const inputValue = ref(model.value ? getLocalizedDayJs(model.value).format('HH:mm') : null);
+
+let selectAllOnMouseUp = false;
+let ignoreNextFocusSelect = props.focus;
+let selectAllOnNextClick = props.focus;
+
+watch(() => props.focus, (newValue) => {
+    if (newValue) {
+        ignoreNextFocusSelect = true;
+        selectAllOnNextClick = true;
+    }
+});
+
+function handleFocus(event: FocusEvent) {
+    if (ignoreNextFocusSelect) {
+        ignoreNextFocusSelect = false;
+        return;
+    }
+    const target = event.target as HTMLInputElement;
+    target.select();
+    selectAllOnMouseUp = true;
+}
+
+function handleMouseUp(event: MouseEvent) {
+    if (selectAllOnNextClick) {
+        const target = event.target as HTMLInputElement;
+        target.select();
+        selectAllOnNextClick = false;
+        selectAllOnMouseUp = false;
+        event.preventDefault();
+        return;
+    }
+    if (selectAllOnMouseUp) {
+        event.preventDefault();
+        selectAllOnMouseUp = false;
+    }
+}
+
+function handleBlur(event: FocusEvent) {
+    selectAllOnNextClick = false;
+    updateTime(event);
+}
 </script>
 
 <template>
@@ -101,12 +142,10 @@ const inputValue = ref(model.value ? getLocalizedDayJs(model.value).format('HH:m
         class="text-center w-full"
         data-testid="time_picker_input"
         type="text"
-        @blur="updateTime"
+        @blur="handleBlur"
         @keydown.enter.prevent="updateTime"
-        @focus="($event.target as HTMLInputElement).select()"
-        @mouseup="($event.target as HTMLInputElement).select()"
-        @click="($event.target as HTMLInputElement).select()"
-        @pointerup="($event.target as HTMLInputElement).select()" />
+        @focus="handleFocus"
+        @mouseup="handleMouseUp" />
 </template>
 
 <style scoped></style>


### PR DESCRIPTION
## What does this PR do?

This PR prevents the repeated select-all text behavior in the `TimePickerSimple` component. Currently, `mouseup`, `click`, and `pointerup` event listeners force a full text selection on every pointer event. While editing was still possible via keyboard navigation, this made editing with the mouse extremely difficult as users could not position the caret or select custom text ranges with clicks.

With this change:
- When the input first receives focus, all text is selected once.
- On subsequent clicks, caret positioning and text selection work normally with the mouse, making editing with the mouse much easier and intuitive.
- Discussion: https://github.com/solidtime-io/solidtime/discussions/1100

## Checklist (DO NOT REMOVE)

- [x] I read the [contributing guide](https://github.com/solidtime-io/solidtime/blob/main/CONTRIBUTING.md)
- [x] I signed the [Contributor License Agreement](https://cla-assistant.io/solidtime-io/solidtime).
- [x] I commented my code, particularly in hard-to-understand areas
