### PR TITLE
Feature/show hide amounts

### DIFF
--- a/app/Http/Controllers/Api/V1/ReportController.php
+++ b/app/Http/Controllers/Api/V1/ReportController.php
@@ -111,6 +111,7 @@ class ReportController extends Controller
         $properties->timezone = $timezone;
         $properties->roundingType = $request->getPropertyRoundingType();
         $properties->roundingMinutes = $request->getPropertyRoundingMinutes();
+        $properties->showAmounts = $request->getPropertyShowAmounts();
         $report->properties = $properties;
         if ($isPublic) {
             $report->share_secret = $reportService->generateSecret();

--- a/app/Http/Controllers/Api/V1/TimeEntryController.php
+++ b/app/Http/Controllers/Api/V1/TimeEntryController.php
@@ -235,7 +235,7 @@ class TimeEntryController extends Controller
         }
         $user = $this->user();
         $timezone = $user->timezone;
-        $showBillableRate = $this->member($organization)->role !== Role::Employee->value || $organization->employees_can_see_billable_rates;
+        $showBillableRate = ($this->member($organization)->role !== Role::Employee->value || $organization->employees_can_see_billable_rates) && $request->getShowAmounts();
         $roundingType = $canAccessPremiumFeatures ? $request->getRoundingType() : null;
         $roundingMinutes = $canAccessPremiumFeatures ? $request->getRoundingMinutes() : null;
 
@@ -432,7 +432,7 @@ class TimeEntryController extends Controller
         }
         $debug = $request->getDebug();
         $user = $this->user();
-        $showBillableRate = $this->member($organization)->role !== Role::Employee->value || $organization->employees_can_see_billable_rates;
+        $showBillableRate = ($this->member($organization)->role !== Role::Employee->value || $organization->employees_can_see_billable_rates) && $request->getShowAmounts();
 
         $group = $request->getGroup();
         $subGroup = $request->getSubGroup();

--- a/app/Http/Requests/V1/Report/ReportStoreRequest.php
+++ b/app/Http/Requests/V1/Report/ReportStoreRequest.php
@@ -177,6 +177,11 @@ class ReportStoreRequest extends BaseFormRequest
                 'numeric',
                 'integer',
             ],
+            // Whether to show amounts in the report
+            'properties.show_amounts' => [
+                'nullable',
+                'boolean',
+            ],
         ];
     }
 
@@ -280,5 +285,14 @@ class ReportStoreRequest extends BaseFormRequest
         }
 
         return (int) $this->input('properties.rounding_minutes');
+    }
+
+    public function getPropertyShowAmounts(): ?bool
+    {
+        if (! $this->has('properties.show_amounts') || $this->input('properties.show_amounts') === null) {
+            return null;
+        }
+
+        return (bool) $this->input('properties.show_amounts');
     }
 }

--- a/app/Http/Requests/V1/TimeEntry/TimeEntryAggregateExportRequest.php
+++ b/app/Http/Requests/V1/TimeEntry/TimeEntryAggregateExportRequest.php
@@ -203,7 +203,21 @@ class TimeEntryAggregateExportRequest extends BaseFormRequest
                 'numeric',
                 'integer',
             ],
+            'show_amounts' => [
+                'nullable',
+                'string',
+                'in:true,false',
+            ],
         ];
+    }
+
+    public function getShowAmounts(): bool
+    {
+        if (! $this->has('show_amounts') || $this->input('show_amounts') === null) {
+            return true;
+        }
+
+        return $this->input('show_amounts') === 'true';
     }
 
     public function getDebug(): bool

--- a/app/Http/Requests/V1/TimeEntry/TimeEntryIndexExportRequest.php
+++ b/app/Http/Requests/V1/TimeEntry/TimeEntryIndexExportRequest.php
@@ -182,7 +182,21 @@ class TimeEntryIndexExportRequest extends TimeEntryIndexRequest
                 'numeric',
                 'integer',
             ],
+            'show_amounts' => [
+                'nullable',
+                'string',
+                'in:true,false',
+            ],
         ];
+    }
+
+    public function getShowAmounts(): bool
+    {
+        if (! $this->has('show_amounts') || $this->input('show_amounts') === null) {
+            return true;
+        }
+
+        return $this->input('show_amounts') === 'true';
     }
 
     public function getDebug(): bool

--- a/app/Http/Resources/V1/Report/DetailedReportResource.php
+++ b/app/Http/Resources/V1/Report/DetailedReportResource.php
@@ -64,6 +64,8 @@ class DetailedReportResource extends BaseResource
                 'rounding_type' => $this->resource->properties->roundingType?->value,
                 /** @var int|null $rounding_minutes Rounding minutes for time entries */
                 'rounding_minutes' => $this->resource->properties->roundingMinutes,
+                /** @var bool|null $show_amounts Whether to show amounts in the report */
+                'show_amounts' => $this->resource->properties->showAmounts,
             ],
             /** @var string $created_at Date when the report was created */
             'created_at' => $this->formatDateTime($this->resource->created_at),

--- a/app/Http/Resources/V1/Report/DetailedWithDataReportResource.php
+++ b/app/Http/Resources/V1/Report/DetailedWithDataReportResource.php
@@ -93,6 +93,8 @@ class DetailedWithDataReportResource extends BaseResource
             'interval_format' => $this->resource->organization->interval_format->value,
             /** @var TimeFormat $time_format Time format */
             'time_format' => $this->resource->organization->time_format->value,
+            /** @var bool $show_amounts Whether to show amounts in the report */
+            'show_amounts' => $this->resource->properties->showAmounts ?? true,
             'properties' => [
                 /** @var string $group Type of first grouping */
                 'group' => $this->resource->properties->group->value,

--- a/app/Service/Dto/ReportPropertiesDto.php
+++ b/app/Service/Dto/ReportPropertiesDto.php
@@ -68,6 +68,8 @@ class ReportPropertiesDto implements Castable
 
     public ?int $roundingMinutes = null;
 
+    public ?bool $showAmounts = null;
+
     /**
      * Get the caster class to use when casting from / to this cast target.
      *
@@ -129,6 +131,8 @@ class ReportPropertiesDto implements Castable
                 $dto->roundingType = isset($data->roundingType) ? TimeEntryRoundingType::from($data->roundingType) : null;
                 // Note: roundingMinutes was added later so it is possible that the value is missing in persisted reports in the DB
                 $dto->roundingMinutes = isset($data->roundingMinutes) ? (int) $data->roundingMinutes : null;
+                // Note: showAmounts was added later so it is possible that the value is missing in persisted reports in the DB
+                $dto->showAmounts = isset($data->showAmounts) ? (bool) $data->showAmounts : null;
 
                 return $dto;
             }
@@ -157,6 +161,7 @@ class ReportPropertiesDto implements Castable
                     'timezone' => $value->timezone,
                     'roundingType' => $value->roundingType?->value,
                     'roundingMinutes' => $value->roundingMinutes,
+                    'showAmounts' => $value->showAmounts,
                 ];
 
                 $jsonString = json_encode($data);

--- a/e2e/reporting.spec.ts
+++ b/e2e/reporting.spec.ts
@@ -11,6 +11,7 @@ import {
     createTimeEntryWithBillableStatusViaApi,
     createBareTimeEntryViaApi,
     createPublicProjectViaApi,
+    createBillableProjectViaApi,
     updateOrganizationSettingViaApi,
 } from './utils/api';
 
@@ -658,6 +659,76 @@ test('test that rounding can be enabled', async ({ page, ctx }) => {
 
     // Verify button text changed to "on"
     await expect(page.getByRole('button', { name: /Rounding on/ })).toBeVisible();
+});
+
+// ──────────────────────────────────────────────────
+// Show Amount Controls Tests
+// ──────────────────────────────────────────────────
+
+test('test that toggling show amount off hides the Cost column', async ({ page, ctx }) => {
+    const projectName = 'ShowAmountProj ' + Math.floor(Math.random() * 10000);
+
+    const project = await createBillableProjectViaApi(ctx, {
+        name: projectName,
+        billable_rate: 10000, // 100.00 per hour
+    });
+    await createTimeEntryViaApi(ctx, {
+        description: `Entry for ${projectName}`,
+        duration: '1h',
+        projectId: project.id,
+        billable: true,
+    });
+
+    await goToReporting(page);
+    await expect(page.getByRole('button', { name: 'Export' })).toBeVisible();
+
+    // Cost column should be visible by default for admin users with billable projects
+    await expect(page.getByText('Cost', { exact: true })).toBeVisible();
+    await expect(page.getByText(/Show amount: on/)).toBeVisible();
+
+    // Toggle show amount off
+    const reportUpdatePromise = waitForReportingUpdate(page);
+    await page.getByText(/Show amount: on/).click();
+    await page.getByRole('option', { name: 'Off' }).click();
+    await reportUpdatePromise;
+
+    // Cost column should no longer be visible
+    await expect(page.getByText('Cost', { exact: true })).not.toBeVisible();
+    await expect(page.getByText(/Show amount: off/)).toBeVisible();
+});
+
+test('test that toggling show amount back on restores the Cost column', async ({ page, ctx }) => {
+    const projectName = 'ShowAmountToggle ' + Math.floor(Math.random() * 10000);
+
+    const project = await createBillableProjectViaApi(ctx, {
+        name: projectName,
+        billable_rate: 10000,
+    });
+    await createTimeEntryViaApi(ctx, {
+        description: `Entry for ${projectName}`,
+        duration: '1h',
+        projectId: project.id,
+        billable: true,
+    });
+
+    await goToReporting(page);
+    await expect(page.getByRole('button', { name: 'Export' })).toBeVisible();
+
+    // Toggle off
+    let reportUpdatePromise = waitForReportingUpdate(page);
+    await page.getByText(/Show amount: on/).click();
+    await page.getByRole('option', { name: 'Off' }).click();
+    await reportUpdatePromise;
+    await expect(page.getByText('Cost', { exact: true })).not.toBeVisible();
+
+    // Toggle back on
+    reportUpdatePromise = waitForReportingUpdate(page);
+    await page.getByText(/Show amount: off/).click();
+    await page.getByRole('option', { name: 'On' }).click();
+    await reportUpdatePromise;
+
+    // Cost column should be visible again
+    await expect(page.getByText('Cost', { exact: true })).toBeVisible();
 });
 
 // ──────────────────────────────────────────────────

--- a/e2e/shared-reports.spec.ts
+++ b/e2e/shared-reports.spec.ts
@@ -916,3 +916,47 @@ test('test that shared report displays cost column correctly aligned with data r
     const costValues = table.getByText(/100/);
     await expect(costValues).toHaveCount(2);
 });
+
+test('test that shared report hides Cost column when saved with show amounts off', async ({
+    page,
+    ctx,
+}) => {
+    const projectName = 'HideAmountProj ' + Math.floor(Math.random() * 10000);
+    const reportName = 'HideAmountReport ' + Math.floor(Math.random() * 10000);
+
+    const project = await createBillableProjectViaApi(ctx, {
+        name: projectName,
+        billable_rate: 10000, // 100.00 per hour
+    });
+    await createTimeEntryViaApi(ctx, {
+        description: `Entry for ${projectName}`,
+        duration: '1h',
+        projectId: project.id,
+        billable: true,
+    });
+
+    await goToReporting(page);
+    await expect(page.getByTestId('reporting_view').getByText(projectName)).toBeVisible();
+
+    // Toggle show amounts off before saving the report
+    const reportUpdatePromise = waitForReportingUpdate(page);
+    await page.getByText(/Show amount: on/).click();
+    await page.getByRole('option', { name: 'Off' }).click();
+    await reportUpdatePromise;
+
+    // Cost column should be hidden in the overview before saving
+    await expect(page.getByText('Cost', { exact: true })).not.toBeVisible();
+
+    // Save the report with show_amounts = false
+    const { shareableLink } = await saveAsSharedReport(page, reportName);
+
+    // Navigate to the shared report
+    await page.goto(shareableLink);
+    await expect(page.getByText('Reporting')).toBeVisible();
+    await expect(page.getByText(projectName)).toBeVisible();
+
+    // Cost column should NOT be visible since show_amounts was off when the report was saved
+    await expect(page.getByText('Cost', { exact: true })).not.toBeVisible();
+    // Duration column should still be visible
+    await expect(page.getByText('Duration', { exact: true })).toBeVisible();
+});

--- a/resources/js/Components/Common/Reporting/ReportingFilterBar.vue
+++ b/resources/js/Components/Common/Reporting/ReportingFilterBar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { CheckCircleIcon, TagIcon, UserGroupIcon } from '@heroicons/vue/20/solid';
+import { CheckCircleIcon, TagIcon, UserGroupIcon, EyeIcon, EyeSlashIcon } from '@heroicons/vue/20/solid';
 import { FolderIcon } from '@heroicons/vue/16/solid';
 import { Check } from '@lucide/vue';
 import { RadioGroupIndicator, RadioGroupItem, RadioGroupRoot, type AcceptableValue } from 'reka-ui';
@@ -30,6 +30,7 @@ const billable = defineModel<'true' | 'false' | null>('billable', { required: tr
 const roundingEnabled = defineModel<boolean>('roundingEnabled', { required: true });
 const roundingType = defineModel<TimeEntryRoundingType>('roundingType', { required: true });
 const roundingMinutes = defineModel<number>('roundingMinutes', { required: true });
+const showAmounts = defineModel<boolean>('showAmounts', { required: true });
 const startDate = defineModel<string>('startDate', { required: true });
 const endDate = defineModel<string>('endDate', { required: true });
 
@@ -167,6 +168,31 @@ async function createTag(name: string) {
                     v-model:type="roundingType"
                     v-model:minutes="roundingMinutes"
                     @change="emit('submit')" />
+                <Select
+                    :model-value="showAmounts ? 'true' : 'false'"
+                    @update:model-value="(v) => (showAmounts = v === 'true')">
+                    <SelectTrigger
+                        size="sm"
+                        variant="outline"
+                        :active="!showAmounts"
+                        :show-chevron="false">
+                        <SelectValue class="flex items-center gap-2">
+                            <EyeSlashIcon
+                                v-if="!showAmounts"
+                                class="h-4 dark:text-accent-300/80 text-accent-400/80" />
+                            <EyeIcon
+                                v-else
+                                class="h-4 text-text-quaternary" />
+                            <span class="text-text-secondary">
+                                Show amount: {{ showAmounts ? 'on' : 'off' }}
+                            </span>
+                        </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="true">On</SelectItem>
+                        <SelectItem value="false">Off</SelectItem>
+                    </SelectContent>
+                </Select>
             </div>
             <div>
                 <DateRangePicker

--- a/resources/js/Components/Common/Reporting/ReportingOverview.vue
+++ b/resources/js/Components/Common/Reporting/ReportingOverview.vue
@@ -132,6 +132,7 @@ const filterParams = computed<AggregatedTimeEntriesQueryParams>(() => {
         member_id: getCurrentRole() === 'employee' ? getCurrentMembershipId() : undefined,
         rounding_type: roundingEnabled.value ? roundingType.value : undefined,
         rounding_minutes: roundingEnabled.value ? roundingMinutes.value : undefined,
+        show_amounts: showAmounts.value,
     };
 });
 

--- a/resources/js/Components/Common/Reporting/ReportingOverview.vue
+++ b/resources/js/Components/Common/Reporting/ReportingOverview.vue
@@ -74,6 +74,7 @@ const billable = ref<'true' | 'false' | null>(null);
 const roundingEnabled = ref<boolean>(false);
 const roundingType = ref<TimeEntryRoundingType>('nearest');
 const roundingMinutes = ref<number>(15);
+const showAmounts = useStorage<boolean>('reporting-show-amounts', true);
 
 const group = useStorage<GroupingOption>('reporting-group', 'project');
 const subGroup = useStorage<GroupingOption>('reporting-sub-group', 'task');
@@ -83,11 +84,13 @@ const { groupByOptions, getNameForReportingRowEntry, emptyPlaceholder } = report
 
 const organization = inject<ComputedRef<Organization>>('organization');
 
-const showBillableRate = computed(() => {
+const canSeeBillableRate = computed(() => {
     return !!(
         getCurrentRole() !== 'employee' || organization?.value?.employees_can_see_billable_rates
     );
 });
+
+const showBillableRate = computed(() => canSeeBillableRate.value && showAmounts.value);
 
 // Ensure sub-group falls back when it collides with group
 watch(
@@ -374,6 +377,8 @@ const tableData = computed(() => {
         v-model:rounding-enabled="roundingEnabled"
         v-model:rounding-type="roundingType"
         v-model:rounding-minutes="roundingMinutes"
+        v-model:show-amounts="showAmounts"
+        :can-toggle-amounts="canSeeBillableRate"
         v-model:start-date="startDate"
         v-model:end-date="endDate" />
     <MainContainer>

--- a/resources/js/Pages/ReportingDetailed.vue
+++ b/resources/js/Pages/ReportingDetailed.vue
@@ -90,6 +90,7 @@ const billable = ref<'true' | 'false' | null>(null);
 const roundingEnabled = ref<boolean>(false);
 const roundingType = ref<TimeEntryRoundingType>('nearest');
 const roundingMinutes = ref<number>(15);
+const showAmounts = ref<boolean>(true);
 
 const { members } = useMembersQuery();
 const { organization } = useOrganizationQuery(getCurrentOrganizationId()!);
@@ -345,6 +346,7 @@ async function downloadExport(format: ExportFormat) {
             v-model:rounding-enabled="roundingEnabled"
             v-model:rounding-type="roundingType"
             v-model:rounding-minutes="roundingMinutes"
+            v-model:show-amounts="showAmounts"
             v-model:start-date="startDate"
             v-model:end-date="endDate"
             @submit="updateFilteredTimeEntries" />

--- a/resources/js/Pages/ReportingDetailed.vue
+++ b/resources/js/Pages/ReportingDetailed.vue
@@ -122,6 +122,7 @@ function getFilterAttributes() {
         billable: billable.value !== null ? billable.value : undefined,
         rounding_type: roundingEnabled.value ? roundingType.value : undefined,
         rounding_minutes: roundingEnabled.value ? roundingMinutes.value : undefined,
+        show_amounts: showAmounts.value,
     };
     return params;
 }

--- a/resources/js/Pages/SharedReport.vue
+++ b/resources/js/Pages/SharedReport.vue
@@ -116,6 +116,10 @@ const subGroup = computed(() => {
     }
     return 'project';
 });
+
+const showAmounts = computed(() => {
+    return sharedReportResponseData.value?.show_amounts ?? true;
+});
 const { emptyPlaceholder } = useReportingStore();
 
 const groupedPieChartData = computed(() => {
@@ -126,7 +130,7 @@ const groupedPieChartData = computed(() => {
                     value: entry.seconds,
                     name:
                         emptyPlaceholder[
-                            aggregatedTableTimeEntries.value?.grouped_type ?? 'project'
+                        aggregatedTableTimeEntries.value?.grouped_type ?? 'project'
                         ] ?? '',
                     color: '#CCCCCC',
                 };
@@ -178,6 +182,7 @@ onMounted(async () => {
 </script>
 
 <template>
+
     <Head :title="sharedReportResponseData?.name" />
 
     <div class="text-text-secondary">
@@ -189,15 +194,13 @@ onMounted(async () => {
         </MainContainer>
         <MainContainer>
             <div class="pt-10 w-full px-3 relative">
-                <ReportingChart
-                    :grouped-type="aggregatedGraphTimeEntries?.grouped_type"
+                <ReportingChart :grouped-type="aggregatedGraphTimeEntries?.grouped_type"
                     :grouped-data="aggregatedGraphTimeEntries?.grouped_data"></ReportingChart>
             </div>
         </MainContainer>
         <MainContainer>
             <div class="sm:grid grid-cols-4 pt-6 items-start">
-                <div
-                    class="col-span-3 bg-card-background rounded-lg border border-card-border pt-3">
+                <div class="col-span-3 bg-card-background rounded-lg border border-card-border pt-3">
                     <div
                         class="text-sm flex text-text-primary items-center font-medium px-6 border-b border-card-background-separator pb-3">
                         Group by
@@ -205,31 +208,27 @@ onMounted(async () => {
                         and
                         <strong class="px-2">{{ getGroupLabel(subGroup) }}</strong>
                     </div>
-                    <div class="grid items-center" style="grid-template-columns: 1fr 100px 150px">
+                    <div class="grid items-center"
+                        :style="`grid-template-columns: 1fr 100px ${showAmounts ? '150px' : ''}`">
                         <div
                             class="contents [&>*]:border-card-background-separator [&>*]:border-b [&>*]:bg-tertiary [&>*]:pb-1.5 [&>*]:pt-1 text-text-secondary text-sm">
                             <div class="pl-6">Name</div>
-                            <div class="text-right">Duration</div>
-                            <div class="text-right pr-6">Cost</div>
+                            <div class="text-right" :class="!showAmounts ? 'pr-6' : ''">Duration</div>
+                            <div v-if="showAmounts" class="text-right pr-6">Cost</div>
                         </div>
-                        <template
-                            v-if="
-                                aggregatedTableTimeEntries?.grouped_data &&
-                                aggregatedTableTimeEntries.grouped_data?.length > 0
-                            ">
-                            <ReportingRow
-                                v-for="entry in tableData"
-                                :key="entry.description ?? 'none'"
-                                :currency="reportCurrency"
-                                :currency-format="reportCurrencyFormat"
-                                :show-cost="true"
-                                :entry="entry"></ReportingRow>
-                            <div
-                                class="contents [&>*]:transition text-text-tertiary [&>*]:h-[50px]">
+                        <template v-if="
+                            aggregatedTableTimeEntries?.grouped_data &&
+                            aggregatedTableTimeEntries.grouped_data?.length > 0
+                        ">
+                            <ReportingRow v-for="entry in tableData" :key="entry.description ?? 'none'"
+                                :currency="reportCurrency" :currency-format="reportCurrencyFormat"
+                                :show-cost="showAmounts" :entry="entry"></ReportingRow>
+                            <div class="contents [&>*]:transition text-text-tertiary [&>*]:h-[50px]">
                                 <div class="flex items-center pl-6 font-medium">
                                     <span>Total</span>
                                 </div>
-                                <div class="justify-end flex items-center font-medium">
+                                <div class="justify-end flex items-center font-medium"
+                                    :class="!showAmounts ? 'pr-6' : ''">
                                     {{
                                         formatReportingDuration(
                                             aggregatedTableTimeEntries.seconds,
@@ -238,24 +237,22 @@ onMounted(async () => {
                                         )
                                     }}
                                 </div>
-                                <div class="justify-end pr-6 flex items-center font-medium">
+                                <div v-if="showAmounts" class="justify-end pr-6 flex items-center font-medium">
                                     {{
                                         aggregatedTableTimeEntries.cost
                                             ? formatCents(
-                                                  aggregatedTableTimeEntries.cost,
-                                                  reportCurrency,
-                                                  reportCurrencyFormat,
-                                                  reportCurrencySymbol,
-                                                  reportNumberFormat
-                                              )
+                                                aggregatedTableTimeEntries.cost,
+                                                reportCurrency,
+                                                reportCurrencyFormat,
+                                                reportCurrencySymbol,
+                                                reportNumberFormat
+                                            )
                                             : '--'
                                     }}
                                 </div>
                             </div>
                         </template>
-                        <div
-                            v-else
-                            class="chart flex flex-col items-center justify-center py-12 col-span-3">
+                        <div v-else class="chart flex flex-col items-center justify-center py-12 col-span-3">
                             <p class="text-lg text-text-primary font-semibold">
                                 No time entries found
                             </p>

--- a/resources/js/packages/api/src/index.ts
+++ b/resources/js/packages/api/src/index.ts
@@ -86,6 +86,7 @@ export type AggregatedTimeEntriesQueryParams = ZodiosQueryParamsByAlias<
     end: string;
     rounding_type?: string;
     rounding_minutes?: number;
+    show_amounts?: boolean;
 };
 
 export type OrganizationResponse = ZodiosResponseByAlias<SolidTimeApi, 'getOrganization'>;

--- a/resources/js/packages/api/src/openapi.json.client.ts
+++ b/resources/js/packages/api/src/openapi.json.client.ts
@@ -457,6 +457,7 @@ const ReportStoreRequest = z
                 timezone: z.union([z.string(), z.null()]).optional(),
                 rounding_type: TimeEntryRoundingType.optional(),
                 rounding_minutes: z.union([z.number(), z.null()]).optional(),
+                show_amounts: z.union([z.boolean(), z.null()]).optional(),
             })
             .passthrough(),
     })
@@ -486,6 +487,7 @@ const DetailedReportResource = z
                 task_ids: z.union([z.array(z.string()), z.null()]),
                 rounding_type: z.union([z.string(), z.null()]),
                 rounding_minutes: z.union([z.number(), z.null()]),
+                show_amounts: z.union([z.boolean(), z.null()]),
             })
             .passthrough(),
         created_at: z.string(),
@@ -513,6 +515,7 @@ const DetailedWithDataReportResource = z
         date_format: DateFormat,
         interval_format: IntervalFormat,
         time_format: TimeFormat,
+        show_amounts: z.boolean(),
         properties: z
             .object({
                 group: z.string(),

--- a/resources/js/packages/api/src/openapi.json.client.ts
+++ b/resources/js/packages/api/src/openapi.json.client.ts
@@ -4384,6 +4384,11 @@ If the group parameters are all set to &#x60;null&#x60; or are all missing, the 
                 type: 'Query',
                 schema: z.array(z.string()).min(1).optional(),
             },
+            {
+                name: 'show_amounts',
+                type: 'Query',
+                schema: z.boolean().optional(),
+            },
         ],
         response: z.union([
             z.object({ download_url: z.string() }).passthrough(),
@@ -4516,6 +4521,11 @@ If the group parameters are all set to &#x60;null&#x60; or are all missing, the 
                 name: 'task_ids',
                 type: 'Query',
                 schema: z.array(z.string()).min(1).optional(),
+            },
+            {
+                name: 'show_amounts',
+                type: 'Query',
+                schema: z.boolean().optional(),
             },
         ],
         response: z.union([

--- a/resources/views/reports/time-entry-aggregate/spreadsheet.blade.php
+++ b/resources/views/reports/time-entry-aggregate/spreadsheet.blade.php
@@ -20,9 +20,11 @@
         <th style="border: 1px solid black; font-weight: bold;" data-type="{{ DataType::TYPE_STRING }}">
             Duration (decimal)
         </th>
+        @if($showBillableRate)
         <th style="border: 1px solid black; font-weight: bold;" data-type="{{ DataType::TYPE_STRING }}">
             Amount ({{ Str::upper($currency) }})
         </th>
+        @endif
     </tr>
     </thead>
     <tbody>
@@ -148,6 +150,7 @@
                     =0
                 @endif
             </td>
+            @if($showBillableRate)
             <td style="border: 1px solid black; font-weight: bold;" data-type="{{ DataType::TYPE_FORMULA }}"
                 data-format="{{ NumberFormat::FORMAT_NUMBER_COMMA_SEPARATED1 }}">
                 @if($counter > 1)
@@ -156,6 +159,7 @@
                     =0
                 @endif
             </td>
+            @endif
         @endif
     </tr>
     </tbody>

--- a/tests/Unit/Endpoint/Api/V1/Public/PublicReportEndpointTest.php
+++ b/tests/Unit/Endpoint/Api/V1/Public/PublicReportEndpointTest.php
@@ -122,6 +122,7 @@ class PublicReportEndpointTest extends ApiEndpointTestAbstract
             'name' => $report->name,
             'description' => $report->description,
             'public_until' => $report->public_until?->toIso8601ZuluString(),
+            'show_amounts' => true,
             'currency' => $organization->currency,
             'number_format' => $organization->number_format,
             'interval_format' => $organization->interval_format,
@@ -667,6 +668,90 @@ class PublicReportEndpointTest extends ApiEndpointTestAbstract
                 'grouped_type' => TimeEntryAggregationType::Project->value,
             ],
         ]);
+    }
+
+    public function test_show_returns_show_amounts_false_when_report_has_it_set(): void
+    {
+        // Arrange
+        $organization = Organization::factory()->create();
+        $reportDto = new ReportPropertiesDto;
+        $reportDto->start = now()->subDays(2);
+        $reportDto->end = now();
+        $reportDto->group = TimeEntryAggregationType::Project;
+        $reportDto->subGroup = TimeEntryAggregationType::Task;
+        $reportDto->historyGroup = TimeEntryAggregationTypeInterval::Day;
+        $reportDto->weekStart = Weekday::Monday;
+        $reportDto->timezone = 'Europe/Vienna';
+        $reportDto->showAmounts = false;
+        $report = Report::factory()->forOrganization($organization)->public()->create([
+            'public_until' => null,
+            'properties' => $reportDto,
+        ]);
+
+        // Act
+        $response = $this->getJson(route('api.v1.public.reports.show'), [
+            'X-Api-Key' => $report->share_secret,
+        ]);
+
+        // Assert
+        $response->assertOk();
+        $response->assertJsonPath('show_amounts', false);
+    }
+
+    public function test_show_returns_show_amounts_true_when_report_has_it_set(): void
+    {
+        // Arrange
+        $organization = Organization::factory()->create();
+        $reportDto = new ReportPropertiesDto;
+        $reportDto->start = now()->subDays(2);
+        $reportDto->end = now();
+        $reportDto->group = TimeEntryAggregationType::Project;
+        $reportDto->subGroup = TimeEntryAggregationType::Task;
+        $reportDto->historyGroup = TimeEntryAggregationTypeInterval::Day;
+        $reportDto->weekStart = Weekday::Monday;
+        $reportDto->timezone = 'Europe/Vienna';
+        $reportDto->showAmounts = true;
+        $report = Report::factory()->forOrganization($organization)->public()->create([
+            'public_until' => null,
+            'properties' => $reportDto,
+        ]);
+
+        // Act
+        $response = $this->getJson(route('api.v1.public.reports.show'), [
+            'X-Api-Key' => $report->share_secret,
+        ]);
+
+        // Assert
+        $response->assertOk();
+        $response->assertJsonPath('show_amounts', true);
+    }
+
+    public function test_show_returns_show_amounts_true_when_report_has_no_preference_set(): void
+    {
+        // Arrange
+        $organization = Organization::factory()->create();
+        $reportDto = new ReportPropertiesDto;
+        $reportDto->start = now()->subDays(2);
+        $reportDto->end = now();
+        $reportDto->group = TimeEntryAggregationType::Project;
+        $reportDto->subGroup = TimeEntryAggregationType::Task;
+        $reportDto->historyGroup = TimeEntryAggregationTypeInterval::Day;
+        $reportDto->weekStart = Weekday::Monday;
+        $reportDto->timezone = 'Europe/Vienna';
+        // showAmounts intentionally left null (not set)
+        $report = Report::factory()->forOrganization($organization)->public()->create([
+            'public_until' => null,
+            'properties' => $reportDto,
+        ]);
+
+        // Act
+        $response = $this->getJson(route('api.v1.public.reports.show'), [
+            'X-Api-Key' => $report->share_secret,
+        ]);
+
+        // Assert: defaults to true when not set
+        $response->assertOk();
+        $response->assertJsonPath('show_amounts', true);
     }
 
     public function test_show_applies_not_contains_tag_match_type(): void

--- a/tests/Unit/Endpoint/Api/V1/ReportEndpointTest.php
+++ b/tests/Unit/Endpoint/Api/V1/ReportEndpointTest.php
@@ -746,4 +746,93 @@ class ReportEndpointTest extends ApiEndpointTestAbstract
         $response->assertStatus(422);
         $response->assertInvalid(['properties.tag_match_type']);
     }
+
+    public function test_store_endpoint_returns_null_for_show_amounts_when_not_set(): void
+    {
+        // Arrange — simulates a report created before show_amounts existed (backward compatibility)
+        $data = $this->createUserWithPermission([
+            'reports:create',
+        ]);
+        Passport::actingAs($data->user);
+
+        // Act
+        $response = $this->withoutExceptionHandling()->postJson(route('api.v1.reports.store', [$data->organization->getKey()]), [
+            'name' => 'Report without show amounts',
+            'is_public' => false,
+            'properties' => [
+                'start' => Carbon::now()->subDays(30)->toIso8601ZuluString(),
+                'end' => Carbon::now()->toIso8601ZuluString(),
+                'group' => TimeEntryAggregationType::Project->value,
+                'sub_group' => TimeEntryAggregationType::Task->value,
+                'history_group' => TimeEntryAggregationType::Day->value,
+            ],
+        ]);
+
+        // Assert
+        $response->assertStatus(201);
+        /** @var Report $report */
+        $report = Report::query()->findOrFail($response->json('data.id'));
+        $this->assertNull($report->properties->showAmounts);
+        $response->assertJsonPath('data.properties.show_amounts', null);
+    }
+
+    public function test_store_endpoint_persists_show_amounts_property(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'reports:create',
+        ]);
+        Passport::actingAs($data->user);
+
+        // Act
+        $response = $this->withoutExceptionHandling()->postJson(route('api.v1.reports.store', [$data->organization->getKey()]), [
+            'name' => 'Report with show amounts',
+            'is_public' => false,
+            'properties' => [
+                'start' => Carbon::now()->subDays(30)->toIso8601ZuluString(),
+                'end' => Carbon::now()->toIso8601ZuluString(),
+                'group' => TimeEntryAggregationType::Project->value,
+                'sub_group' => TimeEntryAggregationType::Task->value,
+                'history_group' => TimeEntryAggregationType::Day->value,
+                'show_amounts' => false,
+            ],
+        ]);
+
+        // Assert
+        $response->assertStatus(201);
+        /** @var Report $report */
+        $report = Report::query()->findOrFail($response->json('data.id'));
+        $this->assertFalse($report->properties->showAmounts);
+        $response->assertJsonPath('data.properties.show_amounts', false);
+    }
+
+    public function test_store_endpoint_persists_show_amounts_true(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'reports:create',
+        ]);
+        Passport::actingAs($data->user);
+
+        // Act
+        $response = $this->withoutExceptionHandling()->postJson(route('api.v1.reports.store', [$data->organization->getKey()]), [
+            'name' => 'Report with show amounts true',
+            'is_public' => false,
+            'properties' => [
+                'start' => Carbon::now()->subDays(30)->toIso8601ZuluString(),
+                'end' => Carbon::now()->toIso8601ZuluString(),
+                'group' => TimeEntryAggregationType::Project->value,
+                'sub_group' => TimeEntryAggregationType::Task->value,
+                'history_group' => TimeEntryAggregationType::Day->value,
+                'show_amounts' => true,
+            ],
+        ]);
+
+        // Assert
+        $response->assertStatus(201);
+        /** @var Report $report */
+        $report = Report::query()->findOrFail($response->json('data.id'));
+        $this->assertTrue($report->properties->showAmounts);
+        $response->assertJsonPath('data.properties.show_amounts', true);
+    }
 }

--- a/tests/Unit/Endpoint/Api/V1/TimeEntryEndpointTest.php
+++ b/tests/Unit/Endpoint/Api/V1/TimeEntryEndpointTest.php
@@ -1560,6 +1560,102 @@ class TimeEntryEndpointTest extends ApiEndpointTestAbstract
         $this->assertResponseCode($response, 200);
     }
 
+    public function test_index_export_endpoint_hides_amounts_when_show_amounts_is_false(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'time-entries:view:all',
+        ]);
+        $timeEntry = TimeEntry::factory()->forOrganization($data->organization)->forMember($data->member)->startWithDuration(Carbon::now(), 100)->create();
+        Passport::actingAs($data->user);
+
+        // Act
+        $response = $this->getJson(route('api.v1.time-entries.index-export', [
+            $data->organization->getKey(),
+            'format' => ExportFormat::CSV,
+            'start' => Carbon::now()->startOfYear()->toIso8601ZuluString(),
+            'end' => Carbon::now()->endOfYear()->toIso8601ZuluString(),
+            'show_amounts' => 'false',
+        ]));
+
+        // Assert
+        $this->assertResponseCode($response, 200);
+    }
+
+    public function test_index_export_endpoint_rejects_invalid_show_amounts_value(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'time-entries:view:all',
+        ]);
+        Passport::actingAs($data->user);
+
+        // Act
+        $response = $this->getJson(route('api.v1.time-entries.index-export', [
+            $data->organization->getKey(),
+            'format' => ExportFormat::CSV,
+            'start' => Carbon::now()->startOfYear()->toIso8601ZuluString(),
+            'end' => Carbon::now()->endOfYear()->toIso8601ZuluString(),
+            'show_amounts' => 'invalid',
+        ]));
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertInvalid(['show_amounts']);
+    }
+
+    public function test_aggregate_export_endpoint_hides_amounts_when_show_amounts_is_false(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'time-entries:view:all',
+        ]);
+        $client = Client::factory()->forOrganization($data->organization)->create();
+        $project = Project::factory()->forOrganization($data->organization)->forClient($client)->create();
+        TimeEntry::factory()->forOrganization($data->organization)->forProject($project)->forMember($data->member)->startWithDuration(Carbon::now(), 100)->create();
+        Passport::actingAs($data->user);
+
+        // Act
+        $response = $this->getJson(route('api.v1.time-entries.aggregate-export', [
+            $data->organization->getKey(),
+            'format' => ExportFormat::CSV,
+            'group' => TimeEntryAggregationType::Client,
+            'sub_group' => TimeEntryAggregationType::Project,
+            'history_group' => TimeEntryAggregationTypeInterval::Month,
+            'start' => Carbon::now()->startOfYear()->toIso8601ZuluString(),
+            'end' => Carbon::now()->endOfYear()->toIso8601ZuluString(),
+            'show_amounts' => 'false',
+        ]));
+
+        // Assert
+        $this->assertResponseCode($response, 200);
+    }
+
+    public function test_aggregate_export_endpoint_rejects_invalid_show_amounts_value(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'time-entries:view:all',
+        ]);
+        Passport::actingAs($data->user);
+
+        // Act
+        $response = $this->getJson(route('api.v1.time-entries.aggregate-export', [
+            $data->organization->getKey(),
+            'format' => ExportFormat::CSV,
+            'group' => TimeEntryAggregationType::Client,
+            'sub_group' => TimeEntryAggregationType::Project,
+            'history_group' => TimeEntryAggregationTypeInterval::Month,
+            'start' => Carbon::now()->startOfYear()->toIso8601ZuluString(),
+            'end' => Carbon::now()->endOfYear()->toIso8601ZuluString(),
+            'show_amounts' => 'invalid',
+        ]));
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertInvalid(['show_amounts']);
+    }
+
     public function test_index_export_endpoint_with_client_ids_filter_returns_filtered_entries(): void
     {
         // Arrange


### PR DESCRIPTION
## What does this PR do?

This PR adds the possibility to show/hide the amounts from the reporting. It:
- Adds a new button in the Reporting section to hide/show the amounts from the reporting.
- As a side effect it:
    - Apply the show/hide amount setting also on shared reporting (as done with other filters)
    - Apply the show/hide amount setting also to all export (PDF, CSV, Excel, OSD).

Some notes:    
- No data migration needed, since the shared reports are already saved as JSON in the database.
- New integration and E2E tests created to cover this new case.

- Implements #1135 
I didn't receive any feedback on the discussion, but I needed the feature so I implemented anyway and used in my personal export, but I think it's worth including in this project.

## Checklist (DO NOT REMOVE)

- [x] I read the [contributing guide](https://github.com/solidtime-io/solidtime/blob/main/CONTRIBUTING.md)
- [x] I signed the [Contributor License Agreement](https://cla-assistant.io/solidtime-io/solidtime).
- [x] I commented my code, particularly in hard-to-understand areas

## Demo

<img width="2545" height="1345" alt="solidtime" src="https://github.com/user-attachments/assets/b952475b-2c40-4c1c-8cb0-3021e27314e8" />
