### PR TITLE
feat: keep tasks visible when search term matches project or client name

### DIFF
--- a/resources/js/packages/ui/src/TimeTracker/TimeTrackerProjectTaskDropdown.test.ts
+++ b/resources/js/packages/ui/src/TimeTracker/TimeTrackerProjectTaskDropdown.test.ts
@@ -87,4 +87,32 @@ describe('TimeTrackerProjectTaskDropdown', () => {
 
         expect(wrapper.emitted('changed')?.at(-1)).toEqual(['', null]);
     });
+
+    it('keeps a project\'s tasks visible when the search term matches the project name', async () => {
+        const project = {
+            id: 'p-dummy',
+            name: 'dummy',
+            color: '#fff',
+            client_id: null,
+            is_archived: false,
+        } as unknown as Project;
+        const tasks = [
+            { id: 't-1', name: 'design', project_id: 'p-dummy', is_done: false },
+            { id: 't-2', name: 'build', project_id: 'p-dummy', is_done: false },
+        ] as unknown as Task[];
+
+        const wrapper = mountDropdown({ projects: [project], tasks });
+        await nextTick();
+        await nextTick();
+
+        const searchInput = wrapper.find('[data-testid="client_dropdown_search"]');
+        await searchInput.setValue('dummy');
+        await nextTick();
+
+        // project itself shows up
+        expect(wrapper.find('[data-project-id="p-dummy"]').exists()).toBe(true);
+        // and its tasks are still available even though they don't match "dummy":
+        // the task expander keeps showing all of the project's tasks
+        expect(wrapper.text()).toContain('2 Tasks');
+    });
 });

--- a/resources/js/packages/ui/src/TimeTracker/TimeTrackerProjectTaskDropdown.vue
+++ b/resources/js/packages/ui/src/TimeTracker/TimeTrackerProjectTaskDropdown.vue
@@ -201,21 +201,24 @@ function updateFilteredResults() {
             return task.project_id === filterProject.id;
         });
 
-        const filteredTasks = projectTasks.filter((filterTask) => {
-            return (
-                filterTask.name
-                    .toLowerCase()
-                    .includes(searchValue.value?.toLowerCase()?.trim() || '') &&
-                (!filterTask.is_done || filterTask.id === task.value)
-            );
+        // tasks that should be selectable regardless of the search term
+        // (open tasks, plus the currently selected one even if it's done)
+        const availableTasks = projectTasks.filter((filterTask) => {
+            return !filterTask.is_done || filterTask.id === task.value;
+        });
+
+        const filteredTasks = availableTasks.filter((filterTask) => {
+            return filterTask.name
+                .toLowerCase()
+                .includes(searchValue.value?.toLowerCase()?.trim() || '');
         });
 
         if (
             (projectNameIncludesSearchTerm || clientNameIncludesSearchTerm) &&
             (!filterProject.is_archived || project.value === filterProject.id)
         ) {
-            // search term matches project name
-            addProjectToFilterObject(tempFilteredClients, filterProject, filteredTasks, false);
+            // search term matches project (or client) name: show all the tasks
+            addProjectToFilterObject(tempFilteredClients, filterProject, availableTasks, false);
         } else if (filteredTasks.length > 0 && !filterProject.is_archived) {
             // search term matches task name
             addProjectToFilterObject(tempFilteredClients, filterProject, filteredTasks, true);


### PR DESCRIPTION
## What does this PR do?

Fixes #436 

### Problem 
In the time tracker's project/task dropdown (`TimeTrackerProjectTaskDropdown`), typing a search term filters clients, projects and tasks. However, when the term matched a project or client name, the project showed up but its tasks disappeared.

The cause: when a project's name (or its client's name) matched the search term, the project was added to the results together with the *task list already filtered by that same search term*. Since the tasks themselves don't contain the project name, that list was empty, so the project rendered with no tasks and the "N Tasks" expander vanished.
  
### Fix
  
Split the two concepts in `updateFilteredResults()`:

- `availableTasks` — the project's selectable tasks (open tasks, plus the currently selected one even if it's done).
- `filteredTasks` — those that *also* match the search term.

Behavior:

- If the **project (or client) name matches**, show **all** of the project's `availableTasks` — the whole project is relevant.
- If **only some tasks match**, show just those (`filteredTasks`), with the project expanded, exactly as before.

## Checklist (DO NOT REMOVE)

- [x] I read the [contributing guide](https://github.com/solidtime-io/solidtime/blob/main/CONTRIBUTING.md)
- [x] I signed the [Contributor License Agreement](https://cla-assistant.io/solidtime-io/solidtime).
- [x] I commented my code, particularly in hard-to-understand areas
