### PR TITLE
Fix awkward wording for time tracker alert email

### DIFF
--- a/resources/views/emails/time-entry-still-running.blade.php
+++ b/resources/views/emails/time-entry-still-running.blade.php
@@ -5,7 +5,7 @@
 {{ __('Your currently running time entry ":description" is now running for more than 8 hours!', ['description' => $timeEntry->description]) }}
 @endif
 
-{{ __('If you forgot to stop the Time Tracker you do that in solidtime:') }}
+{{ __('If you forgot to stop the Time Tracker, you can do so in solidtime:') }}
 
 @component('mail::button', ['url' => $dashboardUrl])
 {{ __('Go to solidtime') }}


### PR DESCRIPTION
I just received this email today, and found the "you do that in solidtime" wording to be a bit awkward.

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Changing the wording from "you do that in solidtime" to "you can do so in solidtime".

## Checklist (DO NOT REMOVE)

- [x] I read the [contributing guide](https://github.com/solidtime-io/solidtime/blob/main/CONTRIBUTING.md)
- [x] I signed the [Contributor License Agreement](https://cla-assistant.io/solidtime-io/solidtime).
- [x] I commented my code, particularly in hard-to-understand areas
