### PR TITLE
fix: set Content-Disposition to attachment on report download URLs

### DIFF
--- a/app/Http/Controllers/Api/V1/TimeEntryController.php
+++ b/app/Http/Controllers/Api/V1/TimeEntryController.php
@@ -334,7 +334,9 @@ class TimeEntryController extends Controller
 
         return response()->json([
             'download_url' => Storage::disk(config('filesystems.private'))
-                ->temporaryUrl($path, now()->addMinutes(5)),
+                ->temporaryUrl($path, now()->addMinutes(5), [
+                    'ResponseContentDisposition' => 'attachment; filename="'.$filename.'"',
+                ]),
         ]);
     }
 
@@ -545,7 +547,9 @@ class TimeEntryController extends Controller
 
         return response()->json([
             'download_url' => Storage::disk(config('filesystems.private'))
-                ->temporaryUrl($path, now()->addMinutes(5)),
+                ->temporaryUrl($path, now()->addMinutes(5), [
+                    'ResponseContentDisposition' => 'attachment; filename="'.$filename.'"',
+                ]),
         ]);
     }
 

--- a/tests/Unit/Endpoint/Api/V1/TimeEntryEndpointTest.php
+++ b/tests/Unit/Endpoint/Api/V1/TimeEntryEndpointTest.php
@@ -945,6 +945,37 @@ class TimeEntryEndpointTest extends ApiEndpointTestAbstract
         $this->assertResponseCode($response, 200);
     }
 
+    public function test_index_export_endpoint_requests_the_download_url_as_an_attachment(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'time-entries:view:all',
+        ]);
+        TimeEntry::factory()->forOrganization($data->organization)->forMember($data->member)->startWithDuration(Carbon::now(), 100)->create();
+        Passport::actingAs($data->user);
+
+        $capturedOptions = null;
+        Storage::disk('local')->buildTemporaryUrlsUsing(function (string $path, $expiration, array $options) use (&$capturedOptions): string {
+            $capturedOptions = $options;
+
+            return 'https://example.com/'.$path;
+        });
+
+        // Act
+        $response = $this->getJson(route('api.v1.time-entries.index-export', [
+            $data->organization->getKey(),
+            'format' => ExportFormat::CSV,
+            'start' => Carbon::now()->startOfYear()->toIso8601ZuluString(),
+            'end' => Carbon::now()->endOfYear()->toIso8601ZuluString(),
+        ]));
+
+        // Assert
+        $this->assertResponseCode($response, 200);
+        $this->assertIsArray($capturedOptions);
+        $this->assertArrayHasKey('ResponseContentDisposition', $capturedOptions);
+        $this->assertStringStartsWith('attachment; filename="', $capturedOptions['ResponseContentDisposition']);
+    }
+
     public function test_index_export_endpoint_can_create_a_detailed_time_entry_report_in_format_ods(): void
     {
         // Arrange
@@ -1317,6 +1348,40 @@ class TimeEntryEndpointTest extends ApiEndpointTestAbstract
 
         // Assert
         $this->assertResponseCode($response, 200);
+    }
+
+    public function test_aggregate_export_endpoint_requests_the_download_url_as_an_attachment(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'time-entries:view:all',
+        ]);
+        TimeEntry::factory()->forOrganization($data->organization)->forMember($data->member)->startWithDuration(Carbon::now(), 100)->create();
+        Passport::actingAs($data->user);
+
+        $capturedOptions = null;
+        Storage::disk('local')->buildTemporaryUrlsUsing(function (string $path, $expiration, array $options) use (&$capturedOptions): string {
+            $capturedOptions = $options;
+
+            return 'https://example.com/'.$path;
+        });
+
+        // Act
+        $response = $this->getJson(route('api.v1.time-entries.aggregate-export', [
+            $data->organization->getKey(),
+            'format' => ExportFormat::CSV,
+            'group' => TimeEntryAggregationType::Client,
+            'sub_group' => TimeEntryAggregationType::Project,
+            'history_group' => TimeEntryAggregationTypeInterval::Month,
+            'start' => Carbon::now()->startOfYear()->toIso8601ZuluString(),
+            'end' => Carbon::now()->endOfYear()->toIso8601ZuluString(),
+        ]));
+
+        // Assert
+        $this->assertResponseCode($response, 200);
+        $this->assertIsArray($capturedOptions);
+        $this->assertArrayHasKey('ResponseContentDisposition', $capturedOptions);
+        $this->assertStringStartsWith('attachment; filename="', $capturedOptions['ResponseContentDisposition']);
     }
 
     public function test_aggregate_export_endpoints_can_create_a_csv_report_as_employee_role_with_show_billable_rate(): void


### PR DESCRIPTION
## Summary

Report exports (CSV/Excel/ODS/PDF) returned a presigned S3 URL without a `ResponseContentDisposition`, so the browser decided how to handle the file per-type instead of always downloading it: PDF opens inline in all browsers, CSV opens as plain text in Safari (downloads in Chrome/Firefox), ODS downloads everywhere. The button says "download" but the actual behavior depended on file type and browser. Matches #1148.

- Pass `ResponseContentDisposition: attachment; filename="..."` (using the export's own generated filename) on both `indexExport`'s and `aggregateExport`'s presigned URLs, matching the AWS `GetObject` API's own parameter for controlling the response header.

Fixes #1148

## Test plan

- [x] Added a test per endpoint (`test_index_export_endpoint_requests_the_download_url_as_an_attachment`, `test_aggregate_export_endpoint_requests_the_download_url_as_an_attachment`) that captures the actual options passed to `Storage::temporaryUrl()` via `buildTemporaryUrlsUsing()` (the fake `local` disk used in tests doesn't reflect `$options` in the returned URL string, so this asserts on the options directly) and confirms `ResponseContentDisposition` is set to `attachment; filename="..."`.
- [x] Verified both new tests fail without the fix and pass with it.
- [x] Full `TimeEntryEndpointTest` suite passes.
- [x] `vendor/bin/pint --test` clean on both changed files.