### PR TITLE
add vouch system requirement for PRs > 50 line changes

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -1,0 +1,23 @@
+# Vouched contributors for solidtime.
+#
+# One handle per line, without the leading @, sorted alphabetically.
+# Prefix a handle with - to denounce them, optionally followed by a reason.
+# Format reference: https://github.com/mitchellh/vouch
+#
+# Maintainers do not need to edit this file by hand. Comment "vouch @user",
+# "unvouch @user" or "denounce @user <reason>" on any issue, pull request or
+# discussion and the vouch workflows will update this file.
+#
+# Collaborators with write access and bots are always allowed and do not need
+# an entry here.
+#
+# Seeded 2026-07-25 from the authors of every merged pull request.
+
+agross
+candideu
+KasparRosin
+korridor
+Onatcer
+ShrootBuck
+smileBeda
+utlark

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -1,0 +1,75 @@
+name: Vouch (check PR)
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/recheck'))
+
+    steps:
+      # Pull requests of 50 changed lines or fewer skip the vouch requirement.
+      - name: "Measure diff size"
+        id: size
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number || github.event.issue.number }}
+
+          # Changes to these files do not count towards the 50-line limit.
+          # One extended regex per line, matched against the whole repo-relative
+          # path, so use a leading .* to match a file in any directory.
+          IGNORED: |
+            package-lock\.json
+            composer\.lock
+            tests/.*
+            e2e/.*
+            .*\.(test|spec)\.(ts|js|vue)
+
+        run: |
+          set -euo pipefail
+          # An empty list yields "^()$", which matches no filename. grep exits
+          # 1 on an empty list, so swallow that rather than fail the step.
+          join() { { grep -vE '^[[:space:]]*$' || true; } | paste -sd'|' -; }
+          ignored="^($(join <<<"$IGNORED"))$"
+
+          total=$(gh api --paginate "repos/$REPO/pulls/$PR/files" \
+            --jq '.[] | [.filename, .additions + .deletions] | @tsv' |
+            awk -F'\t' -v ignored="$ignored" '
+              $1 ~ ignored { next }
+                           { n += $2 }
+              END { print n+0 }')
+          echo "total=$total" >> "$GITHUB_OUTPUT"
+          echo "Countable diff size: $total line(s)"
+
+      - name: "Small patch (denounced users still blocked)"
+        if: fromJSON(steps.size.outputs.total) <= 50
+        uses: mitchellh/vouch/action/check-pr@v1.5.0
+        with:
+          pr-number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          auto-close: true
+          require-vouch: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Full vouch required"
+        if: fromJSON(steps.size.outputs.total) > 50
+        uses: mitchellh/vouch/action/check-pr@v1.5.0
+        with:
+          pr-number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          auto-close: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vouch-manage-by-discussion.yml
+++ b/.github/workflows/vouch-manage-by-discussion.yml
@@ -1,0 +1,33 @@
+name: Vouch (manage by discussion)
+
+# Same commands as vouch-manage-by-issue.yml, but for discussion comments.
+
+on:
+  discussion_comment:
+    types: [created]
+
+concurrency:
+  group: vouch-manage
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  discussions: write
+
+jobs:
+  manage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v7
+
+      - name: "Apply vouch command"
+        uses: mitchellh/vouch/action/manage-by-discussion@v1.5.0
+        with:
+          discussion-number: ${{ github.event.discussion.number }}
+          comment-node-id: ${{ github.event.comment.node_id }}
+          roles: admin,maintain,write
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vouch-manage-by-issue.yml
+++ b/.github/workflows/vouch-manage-by-issue.yml
@@ -1,0 +1,35 @@
+name: Vouch (manage by issue)
+
+# Maintainers comment "vouch @user", "unvouch @user" or "denounce @user <reason>"
+# on any issue or pull request, and this workflow updates .github/VOUCHED.td.
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: vouch-manage
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  manage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v7
+
+      - name: "Apply vouch command"
+        uses: mitchellh/vouch/action/manage-by-issue@v1.5.0
+        with:
+          issue-id: ${{ github.event.issue.number }}
+          comment-id: ${{ github.event.comment.id }}
+          roles: admin,maintain,write
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,22 @@ In order to keep the issues of the repository clean we decided to only use them 
 
 To respect your time and help us manage contributions effectively, please open an issue or start a discussion and wait for approval before submitting a pull request (PR). This does not apply to tiny fixes or changes however, please keep in mind that we might not merge PRs for various reasons. 
 
+### Vouched contributors
+
+Pull requests from authors who are not vouched are closed automatically. This lets us keep up with the volume of AI slop pull requests without a maintainer having to triage every one of them by hand.
+
+Your pull request is not affected if any of the following applies:
+
+- You have write access to this repository.
+- Someone with write access has vouched for you. The list lives in [.github/VOUCHED.td](.github/VOUCHED.td).
+- Your pull request changes 50 lines or fewer. Test files and lockfiles do not count towards that number, so a small fix that comes with tests still qualifies.
+
+To get vouched, open an issue or discussion before you start and explain how you intend to implement the change. We will discuss the approach with you, and only once we have agreed on the implementation does a maintainer comment `vouch @your-handle`, which puts you on the list from then on.
+
+Being vouched only stops your pull requests from being closed automatically. [Only work on approved issues](#only-work-on-approved-issues) still applies to every pull request you send.
+
+Contributors who abuse this are denounced, and their pull requests are closed regardless of size. 
+
 ### Contributor License Agreement
 
 You'll also notice that we’ve set up a [Contributor License Agreement (CLA)](https://cla-assistant.io/solidtime-io/solidtime), which must be signed before any PR can be merged. Don’t worry - the process is quick and only takes a few clicks.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Please open an issue or start a discussion and wait for approval before submitti
 
 **If you submit an AI slop pull request (especially without following the proper procedure), you will be banned from future contributions to solidtime.**
 
+To keep that manageable, pull requests from authors who are not vouched are closed automatically, unless they change 50 lines or fewer. To get vouched, open an issue or discussion first and explain how you intend to implement the change. Once we have agreed on the approach, we vouch for you. See [Vouched contributors](./CONTRIBUTING.md#vouched-contributors).
+
 Please read the [CONTRIBUTING.md](./CONTRIBUTING.md) before sumbitting a Pull Request.
 
 We do accept contributions in the [documentation repository](https://github.com/solidtime-io/docs) f.e. to add new self-hosting guides.


### PR DESCRIPTION
This adds a vouch https://github.com/mitchellh/vouch to the solidtime repository. 

PRs > 50 line changes (excl. test files) are auto-closed unless a user has been vouched for. we will vouch users in discussions or issues after they discussed a solution with us and we agreed on an implementaiton. 

> Responds to comments from collaborators with sufficient role (admin, maintain, write, or triage by default):
> 
> vouch — vouches for the issue author
> vouch @user — vouches for a specific user
> vouch <reason> — vouches for the issue author with a reason
> vouch @user <reason> — vouches for a specific user with a reason
> denounce — denounces the issue author
> denounce @user — denounces a specific user
> denounce <reason> — denounces the issue author with a reason
> denounce @user <reason> — denounces a specific user with a reason
