### PR TITLE
Add metadata to projects and clients with client detail pane

### DIFF
--- a/app/Http/Controllers/Api/V1/ClientController.php
+++ b/app/Http/Controllers/Api/V1/ClientController.php
@@ -75,6 +75,9 @@ class ClientController extends Controller
 
         $client = new Client;
         $client->name = $request->input('name');
+        if ($request->has('metadata')) {
+            $client->metadata = $request->getMetadata();
+        }
         $client->organization()->associate($organization);
         $client->save();
 
@@ -95,6 +98,9 @@ class ClientController extends Controller
         $client->name = $request->input('name');
         if ($request->has('is_archived')) {
             $client->archived_at = $request->getIsArchived() ? Carbon::now() : null;
+        }
+        if ($request->has('metadata')) {
+            $client->metadata = $request->getMetadata();
         }
         $client->save();
 

--- a/app/Http/Controllers/Api/V1/ProjectController.php
+++ b/app/Http/Controllers/Api/V1/ProjectController.php
@@ -109,6 +109,9 @@ class ProjectController extends Controller
         if ($this->canAccessPremiumFeatures($organization) && $request->has('estimated_time')) {
             $project->estimated_time = $request->getEstimatedTime();
         }
+        if ($request->has('metadata')) {
+            $project->metadata = $request->getMetadata();
+        }
         $project->organization()->associate($organization);
         $project->save();
 
@@ -136,6 +139,9 @@ class ProjectController extends Controller
         }
         if ($this->canAccessPremiumFeatures($organization) && $request->has('estimated_time')) {
             $project->estimated_time = $request->getEstimatedTime();
+        }
+        if ($request->has('metadata')) {
+            $project->metadata = $request->getMetadata();
         }
         $oldBillableRate = $project->billable_rate;
         $clientIdChanged = false;

--- a/app/Http/Requests/V1/BaseFormRequest.php
+++ b/app/Http/Requests/V1/BaseFormRequest.php
@@ -25,4 +25,35 @@ class BaseFormRequest extends FormRequest
 
         return $rules;
     }
+
+    /**
+     * Validation rules for a metadata object (string keys, string values, f.e. for external references like Stripe IDs).
+     *
+     * @return array<string, list<string>>
+     */
+    protected function metadataRules(): array
+    {
+        return [
+            'metadata' => [
+                'nullable',
+                'array',
+                'max:50',
+            ],
+            'metadata.*' => [
+                'string',
+                'max:500',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>|null
+     */
+    public function getMetadata(): ?array
+    {
+        assert($this->has('metadata'));
+        $metadata = $this->input('metadata');
+
+        return $metadata === null ? null : (array) $metadata;
+    }
 }

--- a/app/Http/Requests/V1/Client/ClientStoreRequest.php
+++ b/app/Http/Requests/V1/Client/ClientStoreRequest.php
@@ -23,7 +23,7 @@ class ClientStoreRequest extends BaseFormRequest
      */
     public function rules(): array
     {
-        return [
+        return array_merge([
             'name' => [
                 'required',
                 'string',
@@ -34,6 +34,6 @@ class ClientStoreRequest extends BaseFormRequest
                     return $builder->whereBelongsTo($this->organization, 'organization');
                 })->withCustomTranslation('validation.client_name_already_exists'),
             ],
-        ];
+        ], $this->metadataRules());
     }
 }

--- a/app/Http/Requests/V1/Client/ClientUpdateRequest.php
+++ b/app/Http/Requests/V1/Client/ClientUpdateRequest.php
@@ -24,7 +24,7 @@ class ClientUpdateRequest extends BaseFormRequest
      */
     public function rules(): array
     {
-        return [
+        return array_merge([
             // Name of the client
             'name' => [
                 'required',
@@ -39,7 +39,7 @@ class ClientUpdateRequest extends BaseFormRequest
             'is_archived' => [
                 'boolean',
             ],
-        ];
+        ], $this->metadataRules());
     }
 
     public function getIsArchived(): bool

--- a/app/Http/Requests/V1/Project/ProjectStoreRequest.php
+++ b/app/Http/Requests/V1/Project/ProjectStoreRequest.php
@@ -27,7 +27,7 @@ class ProjectStoreRequest extends BaseFormRequest
      */
     public function rules(): array
     {
-        return [
+        return array_merge([
             // Name of the project, the name needs to be unique per client and organization
             'name' => [
                 'required',
@@ -81,7 +81,7 @@ class ProjectStoreRequest extends BaseFormRequest
             'is_public' => [
                 'boolean',
             ],
-        ];
+        ], $this->metadataRules());
     }
 
     public function getIsPublic(): bool

--- a/app/Http/Requests/V1/Project/ProjectUpdateRequest.php
+++ b/app/Http/Requests/V1/Project/ProjectUpdateRequest.php
@@ -28,7 +28,7 @@ class ProjectUpdateRequest extends BaseFormRequest
      */
     public function rules(): array
     {
-        return [
+        return array_merge([
             'name' => [
                 'required',
                 'string',
@@ -80,7 +80,7 @@ class ProjectUpdateRequest extends BaseFormRequest
                 'min:0',
                 'max:2147483647',
             ],
-        ];
+        ], $this->metadataRules());
     }
 
     public function getIsArchived(): bool

--- a/app/Http/Resources/V1/Client/ClientResource.php
+++ b/app/Http/Resources/V1/Client/ClientResource.php
@@ -16,7 +16,7 @@ class ClientResource extends BaseResource
     /**
      * Transform the resource into an array.
      *
-     * @return array<string, string|bool|int|null>
+     * @return array<string, string|bool|int|array<string, string>|null>
      */
     public function toArray(Request $request): array
     {
@@ -27,6 +27,8 @@ class ClientResource extends BaseResource
             'name' => $this->resource->name,
             /** @var bool $is_archived Whether the client is archived */
             'is_archived' => $this->resource->is_archived,
+            /** @var array<string, string> $metadata Custom metadata key-value pairs (f.e. external references like Stripe IDs) */
+            'metadata' => $this->resource->metadata ?? [],
             /** @var string $created_at When the tag was created */
             'created_at' => $this->formatDateTime($this->resource->created_at),
             /** @var string $updated_at When the tag was last updated */

--- a/app/Http/Resources/V1/Project/ProjectCollection.php
+++ b/app/Http/Resources/V1/Project/ProjectCollection.php
@@ -27,7 +27,7 @@ class ProjectCollection extends ResourceCollection implements PaginatedResourceC
     /**
      * Transform the resource collection into an array.
      *
-     * @return array<array<string, string|bool|int|null>>
+     * @return array<array<string, string|bool|int|array<string, string>|null>>
      */
     public function toArray(Request $request): array
     {

--- a/app/Http/Resources/V1/Project/ProjectResource.php
+++ b/app/Http/Resources/V1/Project/ProjectResource.php
@@ -25,7 +25,7 @@ class ProjectResource extends BaseResource
     /**
      * Transform the resource into an array.
      *
-     * @return array<string, string|bool|int|null>
+     * @return array<string, string|bool|int|array<string, string>|null>
      */
     public function toArray(Request $request): array
     {
@@ -50,6 +50,8 @@ class ProjectResource extends BaseResource
             'spent_time' => $this->resource->spent_time,
             /** @var bool $is_public Whether the project is public */
             'is_public' => $this->resource->is_public,
+            /** @var array<string, string> $metadata Custom metadata key-value pairs (f.e. external references like Stripe IDs) */
+            'metadata' => $this->resource->metadata ?? [],
         ];
     }
 }

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -21,6 +21,7 @@ use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
  * @property string $name
  * @property string $organization_id
  * @property-read bool $is_archived
+ * @property array<string, string>|null $metadata
  * @property Carbon|null $archived_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
@@ -45,6 +46,7 @@ class Client extends Model implements AuditableContract
     protected $casts = [
         'name' => 'string',
         'archived_at' => 'datetime',
+        'metadata' => 'array',
     ];
 
     /**

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -31,6 +31,7 @@ use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
  * @property-read bool $is_archived
  * @property int|null $estimated_time
  * @property int $spent_time
+ * @property array<string, string>|null $metadata
  * @property Carbon|null $archived_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
@@ -63,6 +64,7 @@ class Project extends Model implements AuditableContract
         'archived_at' => 'datetime',
         'estimated_time' => 'integer',
         'spent_time' => 'integer',
+        'metadata' => 'array',
     ];
 
     /**

--- a/database/migrations/2026_07_30_000000_add_metadata_columns_to_projects_and_clients_table.php
+++ b/database/migrations/2026_07_30_000000_add_metadata_columns_to_projects_and_clients_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('projects', function (Blueprint $table): void {
+            $table->json('metadata')->nullable();
+        });
+        Schema::table('clients', function (Blueprint $table): void {
+            $table->json('metadata')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('projects', function (Blueprint $table): void {
+            $table->dropColumn('metadata');
+        });
+        Schema::table('clients', function (Blueprint $table): void {
+            $table->dropColumn('metadata');
+        });
+    }
+};

--- a/resources/js/Components/Common/Client/ClientDetailPane.vue
+++ b/resources/js/Components/Common/Client/ClientDetailPane.vue
@@ -1,0 +1,229 @@
+<script setup lang="ts">
+import { computed, inject, ref, watch, type ComputedRef } from 'vue';
+import type { Client, Organization } from '@/packages/api/src';
+import { XMarkIcon, PlusIcon, TrashIcon } from '@heroicons/vue/20/solid';
+import {
+    CheckCircleIcon,
+    ArchiveBoxIcon,
+    PencilSquareIcon,
+    ArchiveBoxIcon as ArchiveBoxIconOutline,
+    TrashIcon as TrashIconOutline,
+} from '@heroicons/vue/24/outline';
+import TextInput from '@/packages/ui/src/Input/TextInput.vue';
+import PrimaryButton from '@/packages/ui/src/Buttons/PrimaryButton.vue';
+import SecondaryButton from '@/packages/ui/src/Buttons/SecondaryButton.vue';
+import ClientEditModal from '@/Components/Common/Client/ClientEditModal.vue';
+import { useClientsStore } from '@/utils/useClients';
+import { useProjectsQuery } from '@/utils/useProjectsQuery';
+import { canUpdateClients, canDeleteClients } from '@/utils/permissions';
+import { formatDate } from '@/packages/ui/src/utils/time';
+
+const props = defineProps<{
+    client: Client;
+}>();
+
+const emit = defineEmits<{
+    close: [];
+}>();
+
+const { projects } = useProjectsQuery();
+const organization = inject<ComputedRef<Organization>>('organization');
+
+const projectCount = computed(() => {
+    return projects.value.filter((project) => project.client_id === props.client.id).length;
+});
+
+const formattedCreatedAt = computed(() => {
+    return formatDate(props.client.created_at, organization?.value?.date_format);
+});
+
+const showEditModal = ref(false);
+const saving = ref(false);
+
+interface MetadataEntry {
+    key: string;
+    value: string;
+}
+
+const metadataEntries = ref<MetadataEntry[]>([]);
+
+function resetMetadataEntries() {
+    metadataEntries.value = Object.entries(props.client.metadata ?? {}).map(([key, value]) => ({
+        key,
+        value,
+    }));
+}
+
+watch(() => props.client.id, resetMetadataEntries, { immediate: true });
+
+const metadataFromEntries = computed(() => {
+    return Object.fromEntries(
+        metadataEntries.value
+            .filter((entry) => entry.key.trim() !== '')
+            .map((entry) => [entry.key.trim(), entry.value])
+    );
+});
+
+const metadataDirty = computed(() => {
+    return (
+        JSON.stringify(metadataFromEntries.value) !== JSON.stringify(props.client.metadata ?? {})
+    );
+});
+
+function addMetadataEntry() {
+    metadataEntries.value.push({ key: '', value: '' });
+}
+
+function removeMetadataEntry(index: number) {
+    metadataEntries.value.splice(index, 1);
+}
+
+async function saveMetadata() {
+    saving.value = true;
+    try {
+        await useClientsStore().updateClient(props.client.id, {
+            name: props.client.name,
+            metadata: metadataFromEntries.value,
+        });
+    } finally {
+        saving.value = false;
+    }
+}
+
+function archiveClient() {
+    useClientsStore().updateClient(props.client.id, {
+        ...props.client,
+        is_archived: !props.client.is_archived,
+    });
+}
+
+function deleteClient() {
+    useClientsStore().deleteClient(props.client.id);
+}
+</script>
+
+<template>
+    <div
+        data-testid="client_detail_pane"
+        class="w-[360px] xl:w-[400px] shrink-0 border-l border-default-background-separator sticky top-0 self-start max-h-screen overflow-y-auto">
+        <ClientEditModal v-model:show="showEditModal" :client="client"></ClientEditModal>
+        <div
+            class="flex items-center justify-between px-4 py-4 border-b border-default-background-separator">
+            <h2 class="text-text-primary font-semibold text-base truncate pr-3">
+                {{ client.name }}
+            </h2>
+            <button
+                aria-label="Close client details"
+                class="text-text-secondary hover:text-text-primary hover:bg-card-background rounded-full p-1 transition"
+                @click="emit('close')">
+                <XMarkIcon class="w-5 h-5"></XMarkIcon>
+            </button>
+        </div>
+
+        <div class="px-4 py-4 space-y-3 border-b border-default-background-separator text-sm">
+            <div class="flex items-center justify-between">
+                <span class="text-text-secondary">Status</span>
+                <span class="flex items-center space-x-1.5 text-text-primary">
+                    <template v-if="client.is_archived">
+                        <ArchiveBoxIcon class="w-4 text-icon-default"></ArchiveBoxIcon>
+                        <span>Archived</span>
+                    </template>
+                    <template v-else>
+                        <CheckCircleIcon class="w-4 text-icon-default"></CheckCircleIcon>
+                        <span>Active</span>
+                    </template>
+                </span>
+            </div>
+            <div class="flex items-center justify-between">
+                <span class="text-text-secondary">Projects</span>
+                <span class="text-text-primary">{{ projectCount }}</span>
+            </div>
+            <div class="flex items-center justify-between">
+                <span class="text-text-secondary">Created</span>
+                <span class="text-text-primary">{{ formattedCreatedAt }}</span>
+            </div>
+        </div>
+
+        <div
+            v-if="canUpdateClients() || canDeleteClients()"
+            class="px-4 py-4 flex flex-wrap gap-2 border-b border-default-background-separator">
+            <SecondaryButton
+                v-if="canUpdateClients()"
+                :icon="PencilSquareIcon"
+                data-testid="client_detail_rename"
+                @click="showEditModal = true"
+                >Rename</SecondaryButton
+            >
+            <SecondaryButton
+                v-if="canUpdateClients()"
+                :icon="ArchiveBoxIconOutline"
+                data-testid="client_detail_archive"
+                @click="archiveClient"
+                >{{ client.is_archived ? 'Unarchive' : 'Archive' }}</SecondaryButton
+            >
+            <SecondaryButton
+                v-if="canDeleteClients()"
+                :icon="TrashIconOutline"
+                class="text-destructive"
+                data-testid="client_detail_delete"
+                @click="deleteClient"
+                >Delete</SecondaryButton
+            >
+        </div>
+
+        <div class="px-4 py-4 space-y-3">
+            <div class="flex items-center justify-between">
+                <h3 class="text-text-primary font-semibold text-sm">Metadata</h3>
+                <SecondaryButton
+                    v-if="canUpdateClients()"
+                    :icon="PlusIcon"
+                    data-testid="client_detail_metadata_add"
+                    @click="addMetadataEntry"
+                    >Add</SecondaryButton
+                >
+            </div>
+            <p class="text-text-secondary text-xs">
+                Key-value pairs to link this client to external systems, f.e. a Stripe customer via
+                <span class="font-mono">stripe_customer_id</span>.
+            </p>
+            <div v-if="metadataEntries.length === 0" class="text-text-secondary text-sm py-2">
+                No metadata yet.
+            </div>
+            <div
+                v-for="(entry, index) in metadataEntries"
+                :key="index"
+                class="flex items-center space-x-2">
+                <TextInput
+                    v-model="entry.key"
+                    :disabled="!canUpdateClients()"
+                    type="text"
+                    placeholder="Key"
+                    class="flex-1 min-w-0 text-sm" />
+                <TextInput
+                    v-model="entry.value"
+                    :disabled="!canUpdateClients()"
+                    type="text"
+                    placeholder="Value"
+                    class="flex-1 min-w-0 text-sm" />
+                <button
+                    v-if="canUpdateClients()"
+                    :aria-label="'Remove metadata entry ' + entry.key"
+                    class="text-text-secondary hover:text-destructive p-1 transition"
+                    @click="removeMetadataEntry(index)">
+                    <TrashIcon class="w-4 h-4"></TrashIcon>
+                </button>
+            </div>
+            <div v-if="metadataDirty && canUpdateClients()" class="pt-1">
+                <PrimaryButton
+                    :class="{ 'opacity-25': saving }"
+                    :disabled="saving"
+                    data-testid="client_detail_metadata_save"
+                    @click="saveMetadata"
+                    >Save Metadata</PrimaryButton
+                >
+            </div>
+        </div>
+    </div>
+</template>
+
+<style scoped></style>

--- a/resources/js/Components/Common/Client/ClientTable.vue
+++ b/resources/js/Components/Common/Client/ClientTable.vue
@@ -24,10 +24,12 @@ const props = defineProps<{
     clients: Client[];
     sortColumn: SortColumn;
     sortDirection: SortDirection;
+    selectedClientId?: string | null;
 }>();
 
 const emit = defineEmits<{
     sort: [column: SortColumn, direction: SortDirection];
+    select: [client: Client];
 }>();
 
 const createClient = ref(false);
@@ -144,7 +146,10 @@ const paginatedClients = computed(() => {
                     </SecondaryButton>
                 </div>
                 <template v-for="client in paginatedClients" :key="client.id">
-                    <ClientTableRow :client="client"></ClientTableRow>
+                    <ClientTableRow
+                        :client="client"
+                        :selected="client.id === props.selectedClientId"
+                        @select="emit('select', $event)"></ClientTableRow>
                 </template>
             </div>
         </div>

--- a/resources/js/Components/Common/Client/ClientTableRow.vue
+++ b/resources/js/Components/Common/Client/ClientTableRow.vue
@@ -25,6 +25,11 @@ const { projects } = useProjectsQuery();
 
 const props = defineProps<{
     client: Client;
+    selected?: boolean;
+}>();
+
+const emit = defineEmits<{
+    select: [client: Client];
 }>();
 
 function deleteClient() {
@@ -48,7 +53,12 @@ const showEditModal = ref(false);
 <template>
     <ContextMenu>
         <ContextMenuTrigger as-child>
-            <TableRow>
+            <TableRow
+                :class="[
+                    '[&>*]:cursor-pointer',
+                    selected ? '[&>*]:!bg-card-background' : '[&>*]:hover:bg-white/5',
+                ]"
+                @click="emit('select', client)">
                 <ClientEditModal v-model:show="showEditModal" :client="client"></ClientEditModal>
                 <div
                     class="whitespace-nowrap flex items-center space-x-5 py-4 pr-3 text-sm font-medium text-text-primary pl-4 sm:pl-6 lg:pl-8 3xl:pl-12">
@@ -72,7 +82,8 @@ const showEditModal = ref(false);
                     </template>
                 </div>
                 <div
-                    class="relative whitespace-nowrap flex items-center pl-3 text-right text-sm font-medium sm:pr-0 pr-4 sm:pr-6 lg:pr-8 3xl:pr-12">
+                    class="relative whitespace-nowrap flex items-center pl-3 text-right text-sm font-medium sm:pr-0 pr-4 sm:pr-6 lg:pr-8 3xl:pr-12"
+                    @click.stop>
                     <ClientMoreOptionsDropdown
                         :client="client"
                         @edit="showEditModal = true"

--- a/resources/js/Pages/Clients.vue
+++ b/resources/js/Pages/Clients.vue
@@ -8,6 +8,8 @@ import { computed, ref } from 'vue';
 import { useClientsQuery } from '@/utils/useClientsQuery';
 import ClientTable from '@/Components/Common/Client/ClientTable.vue';
 import ClientCreateModal from '@/Components/Common/Client/ClientCreateModal.vue';
+import ClientDetailPane from '@/Components/Common/Client/ClientDetailPane.vue';
+import type { Client } from '@/packages/api/src';
 import PageTitle from '@/Components/Common/PageTitle.vue';
 import { canCreateClients } from '@/utils/permissions';
 import { TabBar, TabBarItem } from '@/packages/ui/src';
@@ -48,6 +50,18 @@ const shownClients = computed(() => {
         return client.is_archived;
     });
 });
+
+const selectedClientId = ref<string | null>(null);
+
+// Resolve against the full client list so the pane stays open (with fresh data)
+// when an archive/unarchive moves the client to the other tab.
+const selectedClient = computed(() => {
+    return clients.value.find((client) => client.id === selectedClientId.value);
+});
+
+function handleSelect(client: Client) {
+    selectedClientId.value = selectedClientId.value === client.id ? null : client.id;
+}
 </script>
 
 <template>
@@ -66,10 +80,20 @@ const shownClients = computed(() => {
             >
             <ClientCreateModal v-model:show="createClient"></ClientCreateModal>
         </MainContainer>
-        <ClientTable
-            :clients="shownClients"
-            :sort-column="tableState.sortColumn"
-            :sort-direction="tableState.sortDirection"
-            @sort="handleSort"></ClientTable>
+        <div class="flex items-stretch">
+            <div class="flex-1 min-w-0">
+                <ClientTable
+                    :clients="shownClients"
+                    :sort-column="tableState.sortColumn"
+                    :sort-direction="tableState.sortDirection"
+                    :selected-client-id="selectedClientId"
+                    @sort="handleSort"
+                    @select="handleSelect"></ClientTable>
+            </div>
+            <ClientDetailPane
+                v-if="selectedClient"
+                :client="selectedClient"
+                @close="selectedClientId = null"></ClientDetailPane>
+        </div>
     </AppLayout>
 </template>

--- a/resources/js/packages/api/src/openapi.json.client.ts
+++ b/resources/js/packages/api/src/openapi.json.client.ts
@@ -29,13 +29,23 @@ const ClientResource = z
         id: z.string(),
         name: z.string(),
         is_archived: z.boolean(),
+        metadata: z.record(z.string()),
         created_at: z.string(),
         updated_at: z.string(),
     })
     .passthrough();
-const ClientStoreRequest = z.object({ name: z.string().min(1).max(255) }).passthrough();
+const ClientStoreRequest = z
+    .object({
+        name: z.string().min(1).max(255),
+        metadata: z.union([z.record(z.string().max(500)), z.null()]).optional(),
+    })
+    .passthrough();
 const ClientUpdateRequest = z
-    .object({ name: z.string().min(1).max(255), is_archived: z.boolean().optional() })
+    .object({
+        name: z.string().min(1).max(255),
+        is_archived: z.boolean().optional(),
+        metadata: z.union([z.record(z.string().max(500)), z.null()]).optional(),
+    })
     .passthrough();
 const DestroyWithPasswordRequest = z.object({ password: z.string() }).passthrough();
 const ImportRequest = z.object({ type: z.string(), data: z.string() }).passthrough();
@@ -358,6 +368,7 @@ const ProjectResource = z
         estimated_time: z.union([z.number(), z.null()]),
         spent_time: z.number().int(),
         is_public: z.boolean(),
+        metadata: z.record(z.string()),
     })
     .passthrough();
 const ProjectStoreRequest = z
@@ -369,6 +380,7 @@ const ProjectStoreRequest = z
         client_id: z.union([z.string(), z.null()]).optional(),
         estimated_time: z.union([z.number(), z.null()]).optional(),
         is_public: z.boolean().optional(),
+        metadata: z.union([z.record(z.string().max(500)), z.null()]).optional(),
     })
     .passthrough();
 const ProjectUpdateRequest = z
@@ -381,6 +393,7 @@ const ProjectUpdateRequest = z
         client_id: z.union([z.string(), z.null()]).optional(),
         billable_rate: z.union([z.number(), z.null()]).optional(),
         estimated_time: z.union([z.number(), z.null()]).optional(),
+        metadata: z.union([z.record(z.string().max(500)), z.null()]).optional(),
     })
     .passthrough();
 const ProjectMemberResource = z

--- a/resources/js/packages/ui/src/TimeTracker/TimeTrackerProjectTaskDropdown.vue
+++ b/resources/js/packages/ui/src/TimeTracker/TimeTrackerProjectTaskDropdown.vue
@@ -196,6 +196,7 @@ function addProjectToFilterObject(
             updated_at: '',
             value: '',
             is_archived: false,
+            metadata: {},
             projects: [newProject],
         });
     }
@@ -213,6 +214,7 @@ function updateFilteredResults() {
             updated_at: '',
             value: '',
             is_archived: false,
+            metadata: {},
             projects: [
                 {
                     id: NO_PROJECT_ID,
@@ -228,6 +230,7 @@ function updateFilteredResults() {
                     estimated_time: null,
                     spent_time: 0,
                     is_public: false,
+                    metadata: {},
                 },
             ],
         });

--- a/tests/Unit/Endpoint/Api/V1/ClientEndpointTest.php
+++ b/tests/Unit/Endpoint/Api/V1/ClientEndpointTest.php
@@ -260,6 +260,35 @@ class ClientEndpointTest extends ApiEndpointTestAbstract
         );
     }
 
+    public function test_store_endpoint_creates_new_client_with_metadata(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'clients:create',
+        ]);
+        $clientFake = Client::factory()->make();
+        Passport::actingAs($data->user);
+
+        // Act
+        $response = $this->postJson(route('api.v1.clients.store', [$data->organization->getKey()]), [
+            'name' => $clientFake->name,
+            'metadata' => [
+                'stripe_customer_id' => 'cus_123456789',
+            ],
+        ]);
+
+        // Assert
+        $response->assertStatus(201);
+        $response->assertJson(fn (AssertableJson $json) => $json
+            ->has('data')
+            ->where('data.metadata.stripe_customer_id', 'cus_123456789')
+        );
+        $this->assertDatabaseHas(Client::class, [
+            'name' => $clientFake->name,
+            'organization_id' => $data->organization->getKey(),
+        ]);
+    }
+
     public function test_update_endpoint_fails_if_user_has_no_permission_to_update_clients(): void
     {
         // Arrange
@@ -431,6 +460,105 @@ class ClientEndpointTest extends ApiEndpointTestAbstract
         );
         $client->refresh();
         $this->assertFalse($client->is_archived);
+    }
+
+    public function test_update_endpoint_can_update_metadata(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'clients:update',
+        ]);
+        $client = Client::factory()->forOrganization($data->organization)->create();
+        Passport::actingAs($data->user);
+
+        // Act
+        $response = $this->putJson(route('api.v1.clients.update', [$data->organization->getKey(), $client->getKey()]), [
+            'name' => $client->name,
+            'metadata' => [
+                'stripe_customer_id' => 'cus_123456789',
+            ],
+        ]);
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJson(fn (AssertableJson $json) => $json
+            ->has('data')
+            ->where('data.metadata.stripe_customer_id', 'cus_123456789')
+        );
+        $client->refresh();
+        $this->assertSame(['stripe_customer_id' => 'cus_123456789'], $client->metadata);
+    }
+
+    public function test_update_endpoint_can_remove_metadata_with_null(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'clients:update',
+        ]);
+        $client = Client::factory()->forOrganization($data->organization)->create();
+        $client->metadata = ['stripe_customer_id' => 'cus_123456789'];
+        $client->save();
+        Passport::actingAs($data->user);
+
+        // Act
+        $response = $this->putJson(route('api.v1.clients.update', [$data->organization->getKey(), $client->getKey()]), [
+            'name' => $client->name,
+            'metadata' => null,
+        ]);
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJson(fn (AssertableJson $json) => $json
+            ->has('data')
+            ->where('data.metadata', [])
+        );
+        $client->refresh();
+        $this->assertNull($client->metadata);
+    }
+
+    public function test_update_endpoint_does_not_change_metadata_if_not_sent(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'clients:update',
+        ]);
+        $client = Client::factory()->forOrganization($data->organization)->create();
+        $client->metadata = ['stripe_customer_id' => 'cus_123456789'];
+        $client->save();
+        $clientFake = Client::factory()->make();
+        Passport::actingAs($data->user);
+
+        // Act
+        $response = $this->putJson(route('api.v1.clients.update', [$data->organization->getKey(), $client->getKey()]), [
+            'name' => $clientFake->name,
+        ]);
+
+        // Assert
+        $response->assertStatus(200);
+        $client->refresh();
+        $this->assertSame(['stripe_customer_id' => 'cus_123456789'], $client->metadata);
+    }
+
+    public function test_update_endpoint_fails_if_metadata_value_is_not_a_string(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'clients:update',
+        ]);
+        $client = Client::factory()->forOrganization($data->organization)->create();
+        Passport::actingAs($data->user);
+
+        // Act
+        $response = $this->putJson(route('api.v1.clients.update', [$data->organization->getKey(), $client->getKey()]), [
+            'name' => $client->name,
+            'metadata' => [
+                'nested' => ['not' => 'allowed'],
+            ],
+        ]);
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['metadata.nested']);
     }
 
     public function test_destroy_endpoint_fails_if_user_has_no_permission_to_delete_clients(): void

--- a/tests/Unit/Endpoint/Api/V1/ProjectEndpointTest.php
+++ b/tests/Unit/Endpoint/Api/V1/ProjectEndpointTest.php
@@ -1183,6 +1183,37 @@ class ProjectEndpointTest extends ApiEndpointTestAbstract
         $this->assertFalse($project->is_archived);
     }
 
+    public function test_update_endpoint_can_update_metadata(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'projects:update',
+        ]);
+        $project = Project::factory()->forOrganization($data->organization)->create();
+        $this->assertBillableRateServiceIsUnused();
+        Passport::actingAs($data->user);
+
+        // Act
+        $response = $this->putJson(route('api.v1.projects.update', [$data->organization->getKey(), $project->getKey()]), [
+            'name' => $project->name,
+            'color' => $project->color,
+            'is_billable' => $project->is_billable,
+            'client_id' => null,
+            'metadata' => [
+                'stripe_product_id' => 'prod_123456789',
+            ],
+        ]);
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJson(fn (AssertableJson $json) => $json
+            ->has('data')
+            ->where('data.metadata.stripe_product_id', 'prod_123456789')
+        );
+        $project->refresh();
+        $this->assertSame(['stripe_product_id' => 'prod_123456789'], $project->metadata);
+    }
+
     public function test_update_endpoint_can_make_a_private_project_public(): void
     {
         // Arrange


### PR DESCRIPTION
Adds a nullable json metadata column (string key-value pairs, f.e. for linking a client to a Stripe customer via stripe_customer_id) to projects and clients, exposed and validated on the store/update endpoints and returned in the API resources.

On the clients page, clicking a row now opens a right-aligned detail pane with status/projects/created info, rename/archive/delete actions and an editor for the metadata key-value pairs.

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)

## Checklist (DO NOT REMOVE)

- [ ] I read the [contributing guide](https://github.com/solidtime-io/solidtime/blob/main/CONTRIBUTING.md)
- [ ] I signed the [Contributor License Agreement](https://cla-assistant.io/solidtime-io/solidtime).
- [ ] I commented my code, particularly in hard-to-understand areas
