### PR TITLE
Fix blank labels on shared reports grouped by date intervals

### DIFF
--- a/resources/js/Pages/SharedReport.vue
+++ b/resources/js/Pages/SharedReport.vue
@@ -3,7 +3,7 @@ import MainContainer from '@/packages/ui/src/MainContainer.vue';
 import PageTitle from '@/Components/Common/PageTitle.vue';
 import { ChartBarIcon } from '@heroicons/vue/20/solid';
 import ReportingChart from '@/Components/Common/Reporting/ReportingChart.vue';
-import { formatReportingDuration } from '@/packages/ui/src/utils/time';
+import { formatDate, formatReportingDuration, formatWeek } from '@/packages/ui/src/utils/time';
 import ReportingRow from '@/Components/Common/Reporting/ReportingRow.vue';
 import ReportingPieChart from '@/Components/Common/Reporting/ReportingPieChart.vue';
 import { formatCents } from '@/packages/ui/src/utils/money';
@@ -118,46 +118,47 @@ const subGroup = computed(() => {
 });
 const { emptyPlaceholder } = useReportingStore();
 
+function getEntryName(key: string | null, description: string | null, type?: string | null) {
+    if (key !== null && type && ['day', 'week', 'month', 'year'].includes(type)) {
+        return type === 'week' ? formatWeek(key) : formatDate(key, reportDateFormat.value);
+    }
+    return description ?? emptyPlaceholder[type ?? 'project'] ?? '';
+}
+
 const groupedPieChartData = computed(() => {
+    const groupedType = aggregatedTableTimeEntries.value?.grouped_type;
     return (
         aggregatedTableTimeEntries.value?.grouped_data?.map((entry) => {
-            if (entry.description === null) {
+            const name = getEntryName(entry.key, entry.description, groupedType);
+            if (entry.key === null) {
                 return {
                     value: entry.seconds,
-                    name:
-                        emptyPlaceholder[
-                            aggregatedTableTimeEntries.value?.grouped_type ?? 'project'
-                        ] ?? '',
+                    name,
                     color: '#CCCCCC',
                 };
             }
             return {
                 value: entry.seconds,
-                name: entry.description,
-                color: entry.color ?? getRandomColorWithSeed(entry.description ?? 'none'),
+                name,
+                color: entry.color ?? getRandomColorWithSeed(name),
             };
         }) ?? []
     );
 });
 
 const tableData = computed(() => {
+    const groupedType = aggregatedTableTimeEntries.value?.grouped_type;
     return aggregatedTableTimeEntries.value?.grouped_data?.map((entry) => {
         return {
             seconds: entry.seconds,
             cost: entry.cost,
-            description:
-                entry.description ??
-                emptyPlaceholder[aggregatedTableTimeEntries.value?.grouped_type ?? 'project'] ??
-                '',
+            description: getEntryName(entry.key, entry.description, groupedType),
             grouped_data:
                 entry.grouped_data?.map((el) => {
                     return {
                         seconds: el.seconds,
                         cost: el.cost,
-                        description:
-                            el.description ??
-                            emptyPlaceholder[entry.grouped_type ?? 'project'] ??
-                            '',
+                        description: getEntryName(el.key, el.description, entry.grouped_type),
                     };
                 }) ?? [],
         };
@@ -166,10 +167,21 @@ const tableData = computed(() => {
 
 const { groupByOptions } = useReportingStore();
 
+const dateGroupLabels: Record<string, string> = {
+    day: 'Days',
+    week: 'Weeks',
+    month: 'Months',
+    year: 'Years',
+};
+
 function getGroupLabel(key: string) {
-    return groupByOptions.find((option) => {
-        return option.value === key;
-    })?.label;
+    return (
+        dateGroupLabels[key] ??
+        groupByOptions.find((option) => {
+            return option.value === key;
+        })?.label ??
+        key
+    );
 }
 
 onMounted(async () => {


### PR DESCRIPTION
## What does this PR do?

- Fixes #1200

Shared report links grouped by day, week, month or year rendered without labels: the table rows and pie chart segments had no name and the Group by heading was blank. The backend leaves `description` null for date interval groups (`loadDescriptorsMap` has no branch for them) and the page fell back to `emptyPlaceholder`, which has no date entries either. The chart at the top was the only labeled part because it formats `el.key` itself.

This resolves date group names on the shared report page from `entry.key`, with the same `formatWeek` and `formatDate` helpers that `ReportingChart.vue` already uses and the `date_format` the report payload already carries. Entity groupings keep the existing description and placeholder behavior.

The thinking behind the decisions:

- Fixed in the frontend instead of filling `description` in the backend, so the labels respect the organization date format the payload sends and stay consistent with how the chart right above the table formats the same keys.
- The pie chart's gray bucket now keys on `entry.key === null` instead of `entry.description === null`, because date groups have a null description but a real key. The none bucket stays gray, date slices get their formatted name and a seeded color.
- `getGroupLabel` falls back to the raw value, so the heading cannot render blank for an unknown group type.
- Week keys come out exactly as the chart already shows them ("Week 31"). Day, month and year keys go through `formatDate` like the chart axis does.

## What I tested and how

- `npm run format:check`, `npm run lint` (0 errors) and `npm run test:unit` (185 passing) locally.
- `npm run type-check` reports no issues in the changed file. The only error in my environment is the pre existing `vendor/tightenco/ziggy` resolution in `app.ts`, which needs a composer install and is unrelated to this change.
- Checked in the API client schema that `DetailedWithDataReportResource` includes `key` on both grouping levels, so the public payload already carries everything the page needs.
- I did not run a full backend to view the page live. If you want an e2e case for this I am happy to extend `e2e/shared-reports.spec.ts` with a report grouped by week created through the API.

## Checklist (DO NOT REMOVE)

- [x] I read the [contributing guide](https://github.com/solidtime-io/solidtime/blob/main/CONTRIBUTING.md)
- [x] I signed the [Contributor License Agreement](https://cla-assistant.io/solidtime-io/solidtime).
- [x] I commented my code, particularly in hard-to-understand areas

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/solidtime-io/codesmith/solidtime/pr/1201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788718073&installation_model_id=431217&pr_number=1201&repository=solidtime-io%2Fsolidtime&return_to=https%3A%2F%2Fgithub.com%2Fsolidtime-io%2Fsolidtime%2Fpull%2F1201&signature=06ddb18a16df5933a6f59591e6d580e83e277d4c51a5c9a60cf727a2eed90626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
