### PR TITLE
Extend report grouping to include Date and Week

### DIFF
--- a/app/Http/Controllers/Api/V1/TimeEntryController.php
+++ b/app/Http/Controllers/Api/V1/TimeEntryController.php
@@ -535,7 +535,7 @@ class TimeEntryController extends Controller
                 ->putFileAs($folderPath, new File($tempFolder->path($filenameTemp)), $filename);
         } else {
             Excel::store(
-                new TimeEntriesReportExport($aggregatedData, $format, $currency, $group, $subGroup, $showBillableRate),
+                new TimeEntriesReportExport($aggregatedData, $format, $currency, $group, $subGroup, $showBillableRate, $localizationService),
                 $path,
                 config('filesystems.private'),
                 $format->getExportPackageType(),

--- a/app/Service/LocalizationService.php
+++ b/app/Service/LocalizationService.php
@@ -155,9 +155,10 @@ class LocalizationService
     }
 
     /**
-     * Time group types have no server-side descriptor; Day and Week keys are ISO dates and
+     * Time group types have no server-side descriptor; their keys are ISO dates and are
      * formatted here instead. A Week key is the first day of that week, so it renders as the
-     * range it covers.
+     * range it covers. A Year key is already a bare year, so it is returned unchanged - it must
+     * not be parsed, Carbon reads a four digit string as a time of day.
      */
     public function formatTimeGroupKey(?string $key, TimeEntryAggregationType $groupType): ?string
     {
@@ -173,6 +174,13 @@ class LocalizationService
             $weekStart = Carbon::parse($key);
 
             return $this->formatDate($weekStart).' - '.$this->formatDate($weekStart->copy()->addDays(6));
+        }
+
+        if ($groupType === TimeEntryAggregationType::Month) {
+            // Note: the leading "!" resets all fields the format does not name. Without it the
+            // day of the month is taken from today, and a day that the parsed month does not
+            // have overflows the date into the next month.
+            return Carbon::createFromFormat('!Y-m', $key)->format('F Y');
         }
 
         return $key;

--- a/app/Service/LocalizationService.php
+++ b/app/Service/LocalizationService.php
@@ -155,14 +155,9 @@ class LocalizationService
     }
 
     /**
-     * Time group types have no server-side descriptor, so reports fall back to rendering the raw
-     * aggregation key. For the Day type that key is an ISO date (Y-m-d), which is formatted here
-     * so exports match the rest of the UI instead of leaking the key.
-     *
-     * Week, month and year keys have different shapes ('Y-m-d' for the week start, 'Y-m' and 'Y'),
-     * and are not offered as a grouping in the reporting UI, so they are returned unchanged.
-     * Presenting those needs its own decision: a week rendered as its start date reads as a single
-     * day, and a month rendered with a full date format reads as a specific day.
+     * Time group types have no server-side descriptor; Day and Week keys are ISO dates and
+     * formatted here instead. A Week key is the first day of that week, so it renders as the
+     * range it covers.
      */
     public function formatTimeGroupKey(?string $key, TimeEntryAggregationType $groupType): ?string
     {
@@ -170,11 +165,17 @@ class LocalizationService
             return null;
         }
 
-        if ($groupType !== TimeEntryAggregationType::Day) {
-            return $key;
+        if ($groupType === TimeEntryAggregationType::Day) {
+            return $this->formatDate(Carbon::parse($key));
         }
 
-        return $this->formatDate(Carbon::parse($key));
+        if ($groupType === TimeEntryAggregationType::Week) {
+            $weekStart = Carbon::parse($key);
+
+            return $this->formatDate($weekStart).' - '.$this->formatDate($weekStart->copy()->addDays(6));
+        }
+
+        return $key;
     }
 
     public function setDateFormat(DateFormat $dateFormat): void

--- a/app/Service/LocalizationService.php
+++ b/app/Service/LocalizationService.php
@@ -8,12 +8,14 @@ use App\Enums\CurrencyFormat;
 use App\Enums\DateFormat;
 use App\Enums\IntervalFormat;
 use App\Enums\NumberFormat;
+use App\Enums\TimeEntryAggregationType;
 use App\Enums\TimeFormat;
 use App\Models\Organization;
 use Brick\Math\BigDecimal;
 use Brick\Money\Money;
 use Carbon\CarbonInterface;
 use Carbon\CarbonInterval;
+use Illuminate\Support\Carbon;
 
 class LocalizationService
 {
@@ -150,6 +152,29 @@ class LocalizationService
     public function formatDate(CarbonInterface $date): string
     {
         return $date->format($this->dateFormat->toCarbonFormat());
+    }
+
+    /**
+     * Time group types have no server-side descriptor, so reports fall back to rendering the raw
+     * aggregation key. For the Day type that key is an ISO date (Y-m-d), which is formatted here
+     * so exports match the rest of the UI instead of leaking the key.
+     *
+     * Week, month and year keys have different shapes ('Y-m-d' for the week start, 'Y-m' and 'Y'),
+     * and are not offered as a grouping in the reporting UI, so they are returned unchanged.
+     * Presenting those needs its own decision: a week rendered as its start date reads as a single
+     * day, and a month rendered with a full date format reads as a specific day.
+     */
+    public function formatTimeGroupKey(?string $key, TimeEntryAggregationType $groupType): ?string
+    {
+        if ($key === null) {
+            return null;
+        }
+
+        if ($groupType !== TimeEntryAggregationType::Day) {
+            return $key;
+        }
+
+        return $this->formatDate(Carbon::parse($key));
     }
 
     public function setDateFormat(DateFormat $dateFormat): void

--- a/app/Service/ReportExport/TimeEntriesReportExport.php
+++ b/app/Service/ReportExport/TimeEntriesReportExport.php
@@ -6,6 +6,7 @@ namespace App\Service\ReportExport;
 
 use App\Enums\ExportFormat;
 use App\Enums\TimeEntryAggregationType;
+use App\Service\LocalizationService;
 use Illuminate\View\View;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\FromView;
@@ -48,6 +49,8 @@ class TimeEntriesReportExport implements FromView, ShouldAutoSize, WithCustomCsv
 
     private bool $showBillableRate;
 
+    private LocalizationService $localization;
+
     /**
      * @param array{
      *         grouped_type: string|null,
@@ -68,7 +71,7 @@ class TimeEntriesReportExport implements FromView, ShouldAutoSize, WithCustomCsv
      *         cost: int|null
      *   } $data
      */
-    public function __construct(array $data, ExportFormat $exportFormat, string $currency, TimeEntryAggregationType $group, TimeEntryAggregationType $subGroup, bool $showBillableRate)
+    public function __construct(array $data, ExportFormat $exportFormat, string $currency, TimeEntryAggregationType $group, TimeEntryAggregationType $subGroup, bool $showBillableRate, LocalizationService $localization)
     {
         $this->data = $data;
         $this->exportFormat = $exportFormat;
@@ -76,6 +79,7 @@ class TimeEntriesReportExport implements FromView, ShouldAutoSize, WithCustomCsv
         $this->group = $group;
         $this->subGroup = $subGroup;
         $this->showBillableRate = $showBillableRate;
+        $this->localization = $localization;
     }
 
     public function view(): View
@@ -87,6 +91,7 @@ class TimeEntriesReportExport implements FromView, ShouldAutoSize, WithCustomCsv
             'subGroup' => $this->subGroup,
             'exportFormat' => $this->exportFormat,
             'showBillableRate' => $this->showBillableRate,
+            'localization' => $this->localization,
         ]);
     }
 

--- a/e2e/reporting.spec.ts
+++ b/e2e/reporting.spec.ts
@@ -841,6 +841,50 @@ test('test that setting group by to current sub group triggers sub group fallbac
     await expect(groupBySelects.filter({ hasText: 'Members' }).first()).toBeVisible();
 });
 
+test('test that group by date groups the report by day and formats the date labels with organization settings', async ({
+    page,
+    ctx,
+}) => {
+    await updateOrganizationSettingViaApi(ctx, { date_format: 'point-separated-d-m-yyyy' });
+
+    await createTimeEntryViaApi(ctx, {
+        description: 'Entry for group by date',
+        duration: '1h',
+    });
+
+    // Go to reporting page
+    await goToReporting(page);
+    await expect(page.getByRole('button', { name: 'Export' })).toBeVisible();
+
+    // Find the "Group by" selects within the reporting table
+    const groupBySelects = page.locator('[data-testid="reporting_view"]').getByRole('combobox');
+
+    // Default state: group=Project
+    await groupBySelects.filter({ hasText: 'Project' }).first().click();
+
+    const [aggregateResponse] = await Promise.all([
+        page.waitForResponse(
+            (response) =>
+                response.url().includes('/time-entries/aggregate') &&
+                response.url().includes('group=day') &&
+                response.status() === 200
+        ),
+        page.getByRole('option', { name: 'Date', exact: true }).click(),
+    ]);
+
+    // Verify the API request contains the correct group parameter
+    const requestUrl = new URL(aggregateResponse.url());
+    expect(requestUrl.searchParams.get('group')).toBe('day');
+
+    // The row label is rendered in the organization date format (D.M.YYYY)
+    await expect(
+        page.getByTestId('reporting_view').getByText(/^\d{1,2}\.\d{1,2}\.\d{4}$/)
+    ).toBeVisible();
+    await expect(page.getByTestId('reporting_view').getByText(/^\d{4}-\d{2}-\d{2}$/)).toHaveCount(
+        0
+    );
+});
+
 // ──────────────────────────────────────────────────
 // Export Tests
 // ──────────────────────────────────────────────────

--- a/e2e/reporting.spec.ts
+++ b/e2e/reporting.spec.ts
@@ -10,6 +10,7 @@ import {
     createTimeEntryWithTagViaApi,
     createTimeEntryWithBillableStatusViaApi,
     createBareTimeEntryViaApi,
+    createTimeEntryOnDateViaApi,
     createPublicProjectViaApi,
     updateOrganizationSettingViaApi,
 } from './utils/api';
@@ -883,6 +884,83 @@ test('test that group by date groups the report by day and formats the date labe
     await expect(page.getByTestId('reporting_view').getByText(/^\d{4}-\d{2}-\d{2}$/)).toHaveCount(
         0
     );
+});
+
+test('test that group by week requests week grouping and does not leak the raw group key', async ({
+    page,
+    ctx,
+}) => {
+    await createTimeEntryViaApi(ctx, {
+        description: 'Entry for group by week',
+        duration: '1h',
+    });
+
+    await goToReporting(page);
+    await expect(page.getByRole('button', { name: 'Export' })).toBeVisible();
+
+    const groupBySelects = page.locator('[data-testid="reporting_view"]').getByRole('combobox');
+    await groupBySelects.filter({ hasText: 'Project' }).first().click();
+
+    const [aggregateResponse] = await Promise.all([
+        page.waitForResponse(
+            (response) =>
+                response.url().includes('/time-entries/aggregate') &&
+                response.url().includes('group=week') &&
+                response.status() === 200
+        ),
+        page.getByRole('option', { name: 'Week', exact: true }).click(),
+    ]);
+
+    const requestUrl = new URL(aggregateResponse.url());
+    expect(requestUrl.searchParams.get('group')).toBe('week');
+
+    // The raw group key is the first day of the week and must not leak through.
+    await expect(page.getByTestId('reporting_view').getByText(/^\d{4}-\d{2}-\d{2}$/)).toHaveCount(
+        0
+    );
+});
+
+test('test that group by week labels a week spanning new year with a range crossing the year', async ({
+    page,
+    ctx,
+}) => {
+    await updateOrganizationSettingViaApi(ctx, { date_format: 'slash-separated-dd-mm-yyyy' });
+
+    for (const day of ['2025-12-22', '2025-12-29', '2026-01-05']) {
+        await createTimeEntryOnDateViaApi(ctx, {
+            date: new Date(`${day}T09:00:00Z`),
+            duration: '1h',
+            description: `Entry for ${day}`,
+        });
+    }
+
+    // The reporting page keeps its range in session storage, so seed a range spanning new year
+    // rather than driving the date picker.
+    await page.addInitScript(() => {
+        window.sessionStorage.setItem('reporting-start-date', '2025-12-15');
+        window.sessionStorage.setItem('reporting-end-date', '2026-01-15');
+    });
+
+    await goToReporting(page);
+    await expect(page.getByRole('button', { name: 'Export' })).toBeVisible();
+
+    const groupBySelects = page.locator('[data-testid="reporting_view"]').getByRole('combobox');
+    await groupBySelects.filter({ hasText: 'Project' }).first().click();
+    await Promise.all([
+        page.waitForResponse(
+            (response) =>
+                response.url().includes('/time-entries/aggregate') &&
+                response.url().includes('group=week') &&
+                response.status() === 200
+        ),
+        page.getByRole('option', { name: 'Week', exact: true }).click(),
+    ]);
+
+    const reportingView = page.getByTestId('reporting_view');
+    await expect(reportingView.getByText('22/12/2025 - 28/12/2025', { exact: true })).toBeVisible();
+    await expect(reportingView.getByText('29/12/2025 - 04/01/2026', { exact: true })).toBeVisible();
+    await expect(reportingView.getByText('05/01/2026 - 11/01/2026', { exact: true })).toBeVisible();
+    await expect(reportingView.getByText(/^\d{4}-\d{2}-\d{2}$/)).toHaveCount(0);
 });
 
 // ──────────────────────────────────────────────────

--- a/e2e/shared-reports.spec.ts
+++ b/e2e/shared-reports.spec.ts
@@ -16,6 +16,7 @@ import {
     createTimeEntryWithBillableStatusViaApi,
     createTagViaApi,
     createReportViaApi,
+    updateOrganizationSettingViaApi,
 } from './utils/api';
 import {
     goToReporting,
@@ -66,6 +67,42 @@ test('test that saving a report creates a shared report and its shareable link s
     await expect(page.getByText('Reporting')).toBeVisible();
     await expect(page.getByText(projectName)).toBeVisible();
     await expect(page.getByText('Total')).toBeVisible();
+});
+
+test('test that a shared report grouped by date shows date labels formatted by the organization setting', async ({
+    page,
+    ctx,
+}) => {
+    const reportName = 'DateGroupReport ' + Math.floor(Math.random() * 10000);
+
+    await updateOrganizationSettingViaApi(ctx, { date_format: 'point-separated-d-m-yyyy' });
+    await createTimeEntryViaApi(ctx, {
+        description: 'Entry for date grouping',
+        duration: '1h',
+    });
+
+    await goToReporting(page);
+
+    // Switch the grouping to "Date"
+    const groupBySelects = page.locator('[data-testid="reporting_view"]').getByRole('combobox');
+    await groupBySelects.filter({ hasText: 'Project' }).first().click();
+    await Promise.all([
+        page.waitForResponse(
+            (response) =>
+                response.url().includes('/time-entries/aggregate') &&
+                response.url().includes('group=day') &&
+                response.status() === 200
+        ),
+        page.getByRole('option', { name: 'Date', exact: true }).click(),
+    ]);
+
+    const { shareableLink } = await saveAsSharedReport(page, reportName);
+
+    // Verify row labels are formatted correctly
+    await page.goto(shareableLink);
+    await expect(page.getByText('Total')).toBeVisible();
+    await expect(page.getByText(/^\d{1,2}\.\d{1,2}\.\d{4}$/)).toBeVisible();
+    await expect(page.getByText(/^\d{4}-\d{2}-\d{2}$/)).toHaveCount(0);
 });
 
 test('test that shared report with invalid secret shows no data', async ({ page }) => {

--- a/resources/js/Components/Common/Reporting/ReportingOverview.vue
+++ b/resources/js/Components/Common/Reporting/ReportingOverview.vue
@@ -240,7 +240,8 @@ const groupedPieChartData = computed(() => {
         aggregatedTableTimeEntries.value?.grouped_data?.map((entry) => {
             const name = getNameForReportingRowEntry(
                 entry.key,
-                aggregatedTableTimeEntries.value?.grouped_type ?? null
+                aggregatedTableTimeEntries.value?.grouped_type ?? null,
+                organization?.value?.date_format
             );
             let color = getRandomColorWithSeed(entry.key ?? 'none');
             if (
@@ -255,11 +256,7 @@ const groupedPieChartData = computed(() => {
             }
             return {
                 value: entry.seconds,
-                name:
-                    getNameForReportingRowEntry(
-                        entry.key,
-                        aggregatedTableTimeEntries.value?.grouped_type ?? null
-                    ) ?? '',
+                name: name ?? '',
                 color: color,
             };
         }) ?? []
@@ -269,18 +266,25 @@ const groupedPieChartData = computed(() => {
 const tableData = computed(() => {
     return aggregatedTableTimeEntries.value?.grouped_data?.map((entry) => {
         return {
+            key: entry.key,
             seconds: entry.seconds,
             cost: entry.cost,
             description: getNameForReportingRowEntry(
                 entry.key,
-                aggregatedTableTimeEntries.value?.grouped_type ?? null
+                aggregatedTableTimeEntries.value?.grouped_type ?? null,
+                organization?.value?.date_format
             ),
             grouped_data:
                 entry.grouped_data?.map((el) => {
                     return {
+                        key: el.key,
                         seconds: el.seconds,
                         cost: el.cost,
-                        description: getNameForReportingRowEntry(el.key, entry.grouped_type),
+                        description: getNameForReportingRowEntry(
+                            el.key,
+                            entry.grouped_type,
+                            organization?.value?.date_format
+                        ),
                     };
                 }) ?? [],
         };
@@ -421,9 +425,8 @@ const tableData = computed(() => {
                         ">
                         <ReportingRow
                             v-for="entry in tableData"
-                            :key="entry.description ?? 'none'"
+                            :key="entry.key ?? 'none'"
                             :currency="getOrganizationCurrencyString()"
-                            :type="aggregatedTableTimeEntries.grouped_type"
                             :show-cost="showBillableRate"
                             :entry="entry"></ReportingRow>
                         <div class="contents [&>*]:transition text-text-tertiary [&>*]:h-[50px]">

--- a/resources/js/Components/Common/Reporting/ReportingRow.vue
+++ b/resources/js/Components/Common/Reporting/ReportingRow.vue
@@ -11,6 +11,7 @@ type AggregatedGroupedData = GroupedData & {
 };
 
 type GroupedData = {
+    key: string | null;
     seconds: number;
     cost: number | null;
     description: string | null | undefined;
@@ -72,7 +73,7 @@ const organization = inject<ComputedRef<Organization>>('organization');
         :style="`grid-template-columns: 1fr 150px ${showCost ? '150px' : ''}`">
         <ReportingRow
             v-for="subEntry in entry.grouped_data"
-            :key="subEntry.description ?? 'none'"
+            :key="subEntry.key ?? 'none'"
             :currency="props.currency"
             :show-cost="showCost"
             indent

--- a/resources/js/Components/Dashboard/ThisWeekReportingTable.vue
+++ b/resources/js/Components/Dashboard/ThisWeekReportingTable.vue
@@ -95,20 +95,24 @@ const tableData = computed(() => {
     return (
         aggregatedTableTimeEntries.value?.grouped_data?.map((entry) => {
             return {
+                key: entry.key,
                 seconds: entry.seconds,
                 cost: entry.cost,
                 description: getNameForReportingRowEntry(
                     entry.key,
-                    aggregatedTableTimeEntries.value?.grouped_type ?? null
+                    aggregatedTableTimeEntries.value?.grouped_type ?? null,
+                    organization?.value?.date_format
                 ),
                 grouped_data:
                     entry.grouped_data?.map((el) => {
                         return {
+                            key: el.key,
                             seconds: el.seconds,
                             cost: el.cost,
                             description: getNameForReportingRowEntry(
                                 el.key,
-                                entry.grouped_type ?? null
+                                entry.grouped_type ?? null,
+                                organization?.value?.date_format
                             ),
                         };
                     }) ?? [],
@@ -164,7 +168,7 @@ const showBillableRate = computed(() => {
                 ">
                 <ReportingRow
                     v-for="entry in tableData"
-                    :key="entry.description ?? 'none'"
+                    :key="entry.key ?? 'none'"
                     :currency="getOrganizationCurrencyString()"
                     :show-cost="showBillableRate"
                     :entry="entry"></ReportingRow>

--- a/resources/js/Pages/SharedReport.vue
+++ b/resources/js/Pages/SharedReport.vue
@@ -116,25 +116,43 @@ const subGroup = computed(() => {
     }
     return 'project';
 });
-const { emptyPlaceholder } = useReportingStore();
+const { emptyPlaceholder, getNameForReportingRowEntry } = useReportingStore();
+
+/**
+ * The public report endpoint has no descriptor for time group types, so their labels are
+ * derived from the raw group key.
+ */
+function resolveLabel(
+    description: string | null | undefined,
+    key: string | null | undefined,
+    groupedType: string
+) {
+    if (description !== null && description !== undefined) {
+        return description;
+    }
+    return (
+        getNameForReportingRowEntry(key ?? null, groupedType, reportDateFormat.value) ??
+        emptyPlaceholder[groupedType] ??
+        ''
+    );
+}
 
 const groupedPieChartData = computed(() => {
     return (
         aggregatedTableTimeEntries.value?.grouped_data?.map((entry) => {
-            if (entry.description === null) {
+            const groupedType = aggregatedTableTimeEntries.value?.grouped_type ?? 'project';
+            const name = resolveLabel(entry.description, entry.key, groupedType);
+            if (name === emptyPlaceholder[groupedType]) {
                 return {
                     value: entry.seconds,
-                    name:
-                        emptyPlaceholder[
-                            aggregatedTableTimeEntries.value?.grouped_type ?? 'project'
-                        ] ?? '',
+                    name: name,
                     color: '#CCCCCC',
                 };
             }
             return {
                 value: entry.seconds,
-                name: entry.description,
-                color: entry.color ?? getRandomColorWithSeed(entry.description ?? 'none'),
+                name: name,
+                color: entry.color ?? getRandomColorWithSeed(name),
             };
         }) ?? []
     );
@@ -143,21 +161,25 @@ const groupedPieChartData = computed(() => {
 const tableData = computed(() => {
     return aggregatedTableTimeEntries.value?.grouped_data?.map((entry) => {
         return {
+            key: entry.key,
             seconds: entry.seconds,
             cost: entry.cost,
-            description:
-                entry.description ??
-                emptyPlaceholder[aggregatedTableTimeEntries.value?.grouped_type ?? 'project'] ??
-                '',
+            description: resolveLabel(
+                entry.description,
+                entry.key,
+                aggregatedTableTimeEntries.value?.grouped_type ?? 'project'
+            ),
             grouped_data:
                 entry.grouped_data?.map((el) => {
                     return {
+                        key: el.key,
                         seconds: el.seconds,
                         cost: el.cost,
-                        description:
-                            el.description ??
-                            emptyPlaceholder[entry.grouped_type ?? 'project'] ??
-                            '',
+                        description: resolveLabel(
+                            el.description,
+                            el.key,
+                            entry.grouped_type ?? 'project'
+                        ),
                     };
                 }) ?? [],
         };
@@ -219,7 +241,7 @@ onMounted(async () => {
                             ">
                             <ReportingRow
                                 v-for="entry in tableData"
-                                :key="entry.description ?? 'none'"
+                                :key="entry.key ?? 'none'"
                                 :currency="reportCurrency"
                                 :currency-format="reportCurrencyFormat"
                                 :show-cost="true"

--- a/resources/js/packages/ui/src/utils/time.test.ts
+++ b/resources/js/packages/ui/src/utils/time.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'vitest';
-import { formatHumanReadableDuration, formatReportingDuration, formatWeekRange } from './time';
+import {
+    formatHumanReadableDuration,
+    formatMonth,
+    formatReportingDuration,
+    formatWeekRange,
+} from './time';
 
 const seconds = 14 * 3600 + 45 * 60 + 6; // 14h 45m 06s
 
@@ -58,5 +63,11 @@ describe('formatWeekRange', () => {
         expect(formatWeekRange('2025-12-29', 'slash-separated-dd-mm-yyyy')).toBe(
             '29/12/2025 - 04/01/2026'
         );
+    });
+});
+
+describe('formatMonth', () => {
+    test('renders the name of the month that the key covers', () => {
+        expect(formatMonth('2001-02')).toBe('February 2001');
     });
 });

--- a/resources/js/packages/ui/src/utils/time.test.ts
+++ b/resources/js/packages/ui/src/utils/time.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { formatHumanReadableDuration, formatReportingDuration } from './time';
+import { formatHumanReadableDuration, formatReportingDuration, formatWeekRange } from './time';
 
 const seconds = 14 * 3600 + 45 * 60 + 6; // 14h 45m 06s
 
@@ -39,6 +39,24 @@ describe('formatReportingDuration', () => {
     test('hours-minutes-seconds-colon-separated', () => {
         expect(formatReportingDuration(seconds, 'hours-minutes-seconds-colon-separated')).toBe(
             '14:45:06'
+        );
+    });
+});
+
+describe('formatWeekRange', () => {
+    test('renders the six days following the given first day of the week', () => {
+        expect(formatWeekRange('2026-07-27', 'slash-separated-dd-mm-yyyy')).toBe(
+            '27/07/2026 - 02/08/2026'
+        );
+    });
+
+    test('spans a month boundary', () => {
+        expect(formatWeekRange('2026-07-27')).toBe('27.7.2026 - 2.8.2026');
+    });
+
+    test('spans a year boundary', () => {
+        expect(formatWeekRange('2025-12-29', 'slash-separated-dd-mm-yyyy')).toBe(
+            '29/12/2025 - 04/01/2026'
         );
     });
 });

--- a/resources/js/packages/ui/src/utils/time.ts
+++ b/resources/js/packages/ui/src/utils/time.ts
@@ -237,6 +237,15 @@ export function formatWeek(date: string | null): string {
 }
 
 /*
+ * Returns the range covered by the week starting on the given day.
+ * @param date - first day of a week, in the format of 'YYYY-MM-DD'
+ */
+export function formatWeekRange(date: string, format?: DateFormat): string {
+    const end = getDayJsInstance()(date).add(6, 'day').format('YYYY-MM-DD');
+    return `${formatDate(date, format)} - ${formatDate(end, format)}`;
+}
+
+/*
  * Returns a human readable date format.
  * @param date - date in the format of 'YYYY-MM-DD'
  */

--- a/resources/js/packages/ui/src/utils/time.ts
+++ b/resources/js/packages/ui/src/utils/time.ts
@@ -246,6 +246,15 @@ export function formatWeekRange(date: string, format?: DateFormat): string {
 }
 
 /*
+ * Returns the month that the given key falls in. There is no `DateFormat` variant for a
+ * month, so this is not affected by the organization date format.
+ * @param date - a month, in the format of 'YYYY-MM'
+ */
+export function formatMonth(date: string): string {
+    return getDayJsInstance()(date).format('MMMM YYYY');
+}
+
+/*
  * Returns a human readable date format.
  * @param date - date in the format of 'YYYY-MM-DD'
  */

--- a/resources/js/utils/useReporting.ts
+++ b/resources/js/utils/useReporting.ts
@@ -7,9 +7,10 @@ import { useTasksQuery } from '@/utils/useTasksQuery';
 import { useClientsQuery } from '@/utils/useClientsQuery';
 import { useTagsQuery } from '@/utils/useTagsQuery';
 import { CheckCircleIcon, UserCircleIcon, UserGroupIcon } from '@heroicons/vue/20/solid';
-import { DocumentTextIcon, FolderIcon } from '@heroicons/vue/16/solid';
+import { CalendarIcon, DocumentTextIcon, FolderIcon } from '@heroicons/vue/16/solid';
 import { Coffee } from '@lucide/vue';
 import BillableIcon from '@/packages/ui/src/Icons/BillableIcon.vue';
+import { type DateFormat, formatDate } from '@/packages/ui/src/utils/time';
 
 export type GroupingOption =
     | 'project'
@@ -19,7 +20,8 @@ export type GroupingOption =
     | 'client'
     | 'description'
     | 'tag'
-    | 'type';
+    | 'type'
+    | 'day';
 
 export const useReportingStore = defineStore('reporting', () => {
     // Cache query composables to avoid creating new subscriptions on every call
@@ -40,7 +42,11 @@ export const useReportingStore = defineStore('reporting', () => {
         type: 'Work time',
     } as Record<string, string>;
 
-    function getNameForReportingRowEntry(key: string | null, type: string | null) {
+    function getNameForReportingRowEntry(
+        key: string | null,
+        type: string | null,
+        dateFormat?: DateFormat
+    ) {
         if (type === null) {
             return null;
         }
@@ -75,6 +81,9 @@ export const useReportingStore = defineStore('reporting', () => {
         }
         if (type === 'type') {
             return key === 'break' ? 'Break' : 'Work time';
+        }
+        if (type === 'day') {
+            return formatDate(key, dateFormat);
         }
         return key;
     }
@@ -123,6 +132,11 @@ export const useReportingStore = defineStore('reporting', () => {
             label: 'Tags',
             value: 'tag',
             icon: DocumentTextIcon,
+        },
+        {
+            label: 'Date',
+            value: 'day',
+            icon: CalendarIcon,
         },
     ];
 

--- a/resources/js/utils/useReporting.ts
+++ b/resources/js/utils/useReporting.ts
@@ -15,7 +15,12 @@ import {
 } from '@heroicons/vue/16/solid';
 import { Coffee } from '@lucide/vue';
 import BillableIcon from '@/packages/ui/src/Icons/BillableIcon.vue';
-import { type DateFormat, formatDate, formatWeekRange } from '@/packages/ui/src/utils/time';
+import {
+    type DateFormat,
+    formatDate,
+    formatMonth,
+    formatWeekRange,
+} from '@/packages/ui/src/utils/time';
 
 export type GroupingOption =
     | 'project'
@@ -27,7 +32,9 @@ export type GroupingOption =
     | 'tag'
     | 'type'
     | 'day'
-    | 'week';
+    | 'week'
+    | 'month'
+    | 'year';
 
 export const useReportingStore = defineStore('reporting', () => {
     // Cache query composables to avoid creating new subscriptions on every call
@@ -94,6 +101,10 @@ export const useReportingStore = defineStore('reporting', () => {
         if (type === 'week') {
             return formatWeekRange(key, dateFormat);
         }
+        if (type === 'month') {
+            return formatMonth(key);
+        }
+        // A `year` key is already a bare year, so it falls through unchanged.
         return key;
     }
 

--- a/resources/js/utils/useReporting.ts
+++ b/resources/js/utils/useReporting.ts
@@ -7,10 +7,15 @@ import { useTasksQuery } from '@/utils/useTasksQuery';
 import { useClientsQuery } from '@/utils/useClientsQuery';
 import { useTagsQuery } from '@/utils/useTagsQuery';
 import { CheckCircleIcon, UserCircleIcon, UserGroupIcon } from '@heroicons/vue/20/solid';
-import { CalendarIcon, DocumentTextIcon, FolderIcon } from '@heroicons/vue/16/solid';
+import {
+    CalendarDaysIcon,
+    CalendarIcon,
+    DocumentTextIcon,
+    FolderIcon,
+} from '@heroicons/vue/16/solid';
 import { Coffee } from '@lucide/vue';
 import BillableIcon from '@/packages/ui/src/Icons/BillableIcon.vue';
-import { type DateFormat, formatDate } from '@/packages/ui/src/utils/time';
+import { type DateFormat, formatDate, formatWeekRange } from '@/packages/ui/src/utils/time';
 
 export type GroupingOption =
     | 'project'
@@ -21,7 +26,8 @@ export type GroupingOption =
     | 'description'
     | 'tag'
     | 'type'
-    | 'day';
+    | 'day'
+    | 'week';
 
 export const useReportingStore = defineStore('reporting', () => {
     // Cache query composables to avoid creating new subscriptions on every call
@@ -85,6 +91,9 @@ export const useReportingStore = defineStore('reporting', () => {
         if (type === 'day') {
             return formatDate(key, dateFormat);
         }
+        if (type === 'week') {
+            return formatWeekRange(key, dateFormat);
+        }
         return key;
     }
 
@@ -137,6 +146,11 @@ export const useReportingStore = defineStore('reporting', () => {
             label: 'Date',
             value: 'day',
             icon: CalendarIcon,
+        },
+        {
+            label: 'Week',
+            value: 'week',
+            icon: CalendarDaysIcon,
         },
     ];
 

--- a/resources/views/reports/time-entry-aggregate/pdf.blade.php
+++ b/resources/views/reports/time-entry-aggregate/pdf.blade.php
@@ -194,7 +194,7 @@
                                 @if($group->is(\App\Enums\TimeEntryAggregationType::Billable))
                                     {{ $group1Entry['key'] === '1' ? 'Billable' : 'Non-billable' }}
                                 @else
-                                    {{ $group1Entry['description'] ?? $group1Entry['key'] ?? 'No '.Str::lower($group->description()) }}
+                                    {{ $group1Entry['description'] ?? $localization->formatTimeGroupKey($group1Entry['key'], $group) ?? 'No '.Str::lower($group->description()) }}
                                 @endif
                             </span>
                         </td>
@@ -239,7 +239,7 @@
                 <span style="color: #a1a1aa;">
                     {{ $group->description() }}:
                     </span>
-                {{ $group1Entry['description'] ?? $group1Entry['key'] ?? 'No '.Str::lower($group->description()) }}
+                {{ $group1Entry['description'] ?? $localization->formatTimeGroupKey($group1Entry['key'], $group) ?? 'No '.Str::lower($group->description()) }}
             @endif
         </h2>
 
@@ -278,7 +278,7 @@
                             @if($subGroup->is(\App\Enums\TimeEntryAggregationType::Billable))
                                 {{ $group2Entry['key'] === '1' ? 'Billable' : 'Non-billable' }}
                             @else
-                                {{ $group2Entry['description'] ?? $group2Entry['key'] ?? '-' }}
+                                {{ $group2Entry['description'] ?? $localization->formatTimeGroupKey($group2Entry['key'], $subGroup) ?? '-' }}
                             @endif
                         </td>
                         <td>
@@ -318,7 +318,7 @@
 
         series: [
             {
-                data: {!! json_encode(collect($aggregatedData['grouped_data'])->map(function (array $data) use (&$colorService, $group): object {
+                data: {!! json_encode(collect($aggregatedData['grouped_data'])->map(function (array $data) use (&$colorService, $group, $localization): object {
                     $color = $data['color'];
                     if ($color === null) {
                         $color = $colorService->getRandomColor($data['key']);
@@ -328,7 +328,7 @@
                     }
                     return (object)[
                         'value' => $data['seconds'],
-                        'name' => $data['description'] ?? $data['key'] ?? 'No '.Str::lower($group->description()),
+                        'name' => $data['description'] ?? $localization->formatTimeGroupKey($data['key'], $group) ?? 'No '.Str::lower($group->description()),
                         'color' => $color,
                         'itemStyle' => (object) [
                             'color' => $color,

--- a/resources/views/reports/time-entry-aggregate/spreadsheet.blade.php
+++ b/resources/views/reports/time-entry-aggregate/spreadsheet.blade.php
@@ -44,7 +44,7 @@
                         </td>
                     @else
                         <td style="border: 1px solid black;" data-type="{{ DataType::TYPE_STRING }}">
-                            {{ $group1Entry['description'] ?? $group1Entry['key'] ?? '-' }}
+                            {{ $group1Entry['description'] ?? $localization->formatTimeGroupKey($group1Entry['key'], $group) ?? '-' }}
                         </td>
                     @endif
                     @if ($subGroup === TimeEntryAggregationType::Billable)
@@ -53,7 +53,7 @@
                         </td>
                     @else
                         <td style="border: 1px solid black;" data-type="{{ DataType::TYPE_STRING }}">
-                            {{ $group2Entry['description'] ?? $group2Entry['key'] ?? '-' }}
+                            {{ $group2Entry['description'] ?? $localization->formatTimeGroupKey($group2Entry['key'], $subGroup) ?? '-' }}
                         </td>
                     @endif
                     <td style="border: 1px solid black;" data-type="{{ DataType::TYPE_STRING }}">
@@ -74,7 +74,7 @@
                         </td>
                     @else
                         <td style="border: 1px solid black;" data-type="{{ DataType::TYPE_STRING }}">
-                            {{ $group1Entry['description'] ?? $group1Entry['key'] ?? '-' }}
+                            {{ $group1Entry['description'] ?? $localization->formatTimeGroupKey($group1Entry['key'], $group) ?? '-' }}
                         </td>
                     @endif
                     @if ($subGroup === TimeEntryAggregationType::Billable)
@@ -83,7 +83,7 @@
                         </td>
                     @else
                         <td style="border: 1px solid black;" data-type="{{ DataType::TYPE_STRING }}">
-                            {{ $group2Entry['description'] ?? $group2Entry['key'] ?? '-' }}
+                            {{ $group2Entry['description'] ?? $localization->formatTimeGroupKey($group2Entry['key'], $subGroup) ?? '-' }}
                         </td>
                     @endif
                     <td style="border: 1px solid black;" data-type="{{ DataType::TYPE_NUMERIC }}"

--- a/tests/Unit/Endpoint/Api/V1/TimeEntryEndpointTest.php
+++ b/tests/Unit/Endpoint/Api/V1/TimeEntryEndpointTest.php
@@ -17,6 +17,7 @@ use App\Jobs\RecalculateSpentTimeForProject;
 use App\Jobs\RecalculateSpentTimeForTask;
 use App\Models\Client;
 use App\Models\Member;
+use App\Models\Organization;
 use App\Models\Project;
 use App\Models\Tag;
 use App\Models\Task;
@@ -1740,6 +1741,112 @@ class TimeEntryEndpointTest extends ApiEndpointTestAbstract
         $this->assertIsString($csv);
         $this->assertStringContainsString('14/03/2024', $csv);
         $this->assertStringNotContainsString('2024-03-14', $csv);
+    }
+
+    /**
+     * @return array{0: Organization, 1: Member, 2: User}
+     */
+    private function createWeeksSpanningNewYear(): array
+    {
+        $data = $this->createUserWithPermission([
+            'time-entries:view:all',
+        ]);
+        // Note: the organization factory randomizes the date format, so pin it
+        $data->organization->update(['date_format' => DateFormat::SlashSeparatedDDMMYYYY]);
+        $project = Project::factory()->forOrganization($data->organization)->create();
+        // Note: the user factory pins the week start to Monday, so these land in predictable buckets
+        foreach (['2025-12-22', '2025-12-29', '2026-01-05'] as $day) {
+            TimeEntry::factory()->forOrganization($data->organization)->forProject($project)->forMember($data->member)
+                ->startWithDuration(Carbon::parse($day.' 09:00:00', 'UTC'), 3600)->create();
+        }
+
+        return [$data->organization, $data->member, $data->user];
+    }
+
+    public function test_aggregate_export_csv_labels_a_week_group_with_its_date_range(): void
+    {
+        // Arrange
+        $this->travelTo(Carbon::create(2026, 1, 15, 12, 0, 0, 'UTC'));
+        [$organization, , $user] = $this->createWeeksSpanningNewYear();
+        Passport::actingAs($user);
+
+        // Act
+        $response = $this->getJson(route('api.v1.time-entries.aggregate-export', [
+            $organization->getKey(),
+            'format' => ExportFormat::CSV,
+            'group' => TimeEntryAggregationType::Week,
+            'sub_group' => TimeEntryAggregationType::Project,
+            'history_group' => TimeEntryAggregationTypeInterval::Week,
+            'start' => Carbon::parse('2025-12-15 00:00:00', 'UTC')->toIso8601ZuluString(),
+            'end' => Carbon::parse('2026-01-15 23:59:59', 'UTC')->toIso8601ZuluString(),
+        ]));
+
+        // Assert
+        $this->assertResponseCode($response, 200);
+        $disk = Storage::disk(config('filesystems.private'));
+        $files = $disk->files('exports');
+        $this->assertCount(1, $files);
+        $csv = $disk->get($files[0]);
+        $this->assertIsString($csv);
+        $this->assertStringContainsString('22/12/2025 - 28/12/2025', $csv);
+        $this->assertStringContainsString('29/12/2025 - 04/01/2026', $csv);
+        $this->assertStringContainsString('05/01/2026 - 11/01/2026', $csv);
+        $this->assertStringNotContainsString('2025-12-29', $csv);
+        $this->assertStringNotContainsString('2025-12-22', $csv);
+    }
+
+    public function test_aggregate_export_endpoints_can_create_a_pdf_report_grouped_by_week_spanning_new_year(): void
+    {
+        // Arrange
+        $this->travelTo(Carbon::create(2026, 1, 15, 12, 0, 0, 'UTC'));
+        [$organization, , $user] = $this->createWeeksSpanningNewYear();
+        Passport::actingAs($user);
+        $this->actAsOrganizationWithSubscription();
+
+        // Act
+        // Note: a week 1 label carries a comma and reaches the echarts series in a <script> tag
+        $response = $this->getJson(route('api.v1.time-entries.aggregate-export', [
+            $organization->getKey(),
+            'format' => ExportFormat::PDF,
+            'group' => TimeEntryAggregationType::Week,
+            'sub_group' => TimeEntryAggregationType::Project,
+            'history_group' => TimeEntryAggregationTypeInterval::Week,
+            'start' => Carbon::parse('2025-12-15 00:00:00', 'UTC')->toIso8601ZuluString(),
+            'end' => Carbon::parse('2026-01-15 23:59:59', 'UTC')->toIso8601ZuluString(),
+        ]));
+
+        // Assert
+        $this->assertResponseCode($response, 200);
+    }
+
+    public function test_aggregate_export_pdf_labels_a_week_group_with_its_date_range(): void
+    {
+        // Arrange
+        $this->travelTo(Carbon::create(2026, 1, 15, 12, 0, 0, 'UTC'));
+        [$organization, , $user] = $this->createWeeksSpanningNewYear();
+        Passport::actingAs($user);
+        $this->actAsOrganizationWithSubscription();
+
+        // Act
+        // Note: debug=true returns the rendered HTML instead of handing it to the PDF renderer.
+        $response = $this->getJson(route('api.v1.time-entries.aggregate-export', [
+            $organization->getKey(),
+            'format' => ExportFormat::PDF,
+            'group' => TimeEntryAggregationType::Week,
+            'sub_group' => TimeEntryAggregationType::Project,
+            'history_group' => TimeEntryAggregationTypeInterval::Week,
+            'start' => Carbon::parse('2025-12-15 00:00:00', 'UTC')->toIso8601ZuluString(),
+            'end' => Carbon::parse('2026-01-15 23:59:59', 'UTC')->toIso8601ZuluString(),
+            'debug' => 'true',
+        ]));
+
+        // Assert
+        $this->assertResponseCode($response, 200);
+        $html = $response->json('html');
+        $this->assertIsString($html);
+        $this->assertStringContainsString('22/12/2025 - 28/12/2025', $html);
+        $this->assertStringContainsString('29/12/2025 - 04/01/2026', $html);
+        $this->assertStringNotContainsString('2025-12-29', $html);
     }
 
     public function test_index_export_endpoint_with_client_ids_filter_returns_filtered_entries(): void

--- a/tests/Unit/Endpoint/Api/V1/TimeEntryEndpointTest.php
+++ b/tests/Unit/Endpoint/Api/V1/TimeEntryEndpointTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Endpoint\Api\V1;
 
+use App\Enums\DateFormat;
 use App\Enums\ExportFormat;
 use App\Enums\Role;
 use App\Enums\TagMatchType;
@@ -1639,6 +1640,106 @@ class TimeEntryEndpointTest extends ApiEndpointTestAbstract
 
         // Assert
         $this->assertResponseCode($response, 200);
+    }
+
+    public function test_aggregate_export_endpoints_can_create_a_pdf_report_grouped_by_date(): void
+    {
+        // Arrange
+        $data = $this->createUserWithPermission([
+            'time-entries:view:all',
+        ]);
+        $client = Client::factory()->forOrganization($data->organization)->create();
+        $project = Project::factory()->forOrganization($data->organization)->forClient($client)->create();
+        $timeEntry1 = TimeEntry::factory()->forOrganization($data->organization)->forMember($data->member)->startWithDuration(Carbon::now(), 100)->create();
+        $timeEntry2 = TimeEntry::factory()->forOrganization($data->organization)->forProject($project)->forMember($data->member)->startWithDuration(Carbon::now(), 100)->create();
+        Passport::actingAs($data->user);
+        $this->actAsOrganizationWithSubscription();
+
+        // Act
+        $response = $this->getJson(route('api.v1.time-entries.aggregate-export', [
+            $data->organization->getKey(),
+            'format' => ExportFormat::PDF,
+            'group' => TimeEntryAggregationType::Day,
+            'sub_group' => TimeEntryAggregationType::Project,
+            'history_group' => TimeEntryAggregationTypeInterval::Day,
+            'start' => Carbon::now()->startOfYear()->toIso8601ZuluString(),
+            'end' => Carbon::now()->endOfYear()->toIso8601ZuluString(),
+        ]));
+
+        // Assert
+        $this->assertResponseCode($response, 200);
+    }
+
+    public function test_aggregate_export_pdf_renders_date_group_labels_in_organization_date_format(): void
+    {
+        // Arrange
+        $this->travelTo(Carbon::create(2024, 3, 15, 12, 0, 0, 'UTC'));
+        $data = $this->createUserWithPermission([
+            'time-entries:view:all',
+        ]);
+        // Note: the organization factory randomizes the date format, so pin it
+        $data->organization->update(['date_format' => DateFormat::SlashSeparatedDDMMYYYY]);
+        $project = Project::factory()->forOrganization($data->organization)->create();
+        TimeEntry::factory()->forOrganization($data->organization)->forProject($project)->forMember($data->member)
+            ->startWithDuration(Carbon::now()->subDay(), 3600)->create();
+        Passport::actingAs($data->user);
+        $this->actAsOrganizationWithSubscription();
+
+        // Act
+        // Note: debug=true returns the rendered HTML instead of handing it to the PDF renderer.
+        $response = $this->getJson(route('api.v1.time-entries.aggregate-export', [
+            $data->organization->getKey(),
+            'format' => ExportFormat::PDF,
+            'group' => TimeEntryAggregationType::Day,
+            'sub_group' => TimeEntryAggregationType::Project,
+            'history_group' => TimeEntryAggregationTypeInterval::Day,
+            'start' => Carbon::now()->subDays(7)->toIso8601ZuluString(),
+            'end' => Carbon::now()->toIso8601ZuluString(),
+            'debug' => 'true',
+        ]));
+
+        // Assert
+        $this->assertResponseCode($response, 200);
+        $html = $response->json('html');
+        $this->assertIsString($html);
+        $this->assertStringContainsString('14/03/2024', $html);
+        $this->assertStringNotContainsString('2024-03-14', $html);
+    }
+
+    public function test_aggregate_export_csv_renders_date_group_labels_in_organization_date_format(): void
+    {
+        // Arrange
+        $this->travelTo(Carbon::create(2024, 3, 15, 12, 0, 0, 'UTC'));
+        $data = $this->createUserWithPermission([
+            'time-entries:view:all',
+        ]);
+        // Note: the organization factory randomizes the date format, so pin it
+        $data->organization->update(['date_format' => DateFormat::SlashSeparatedDDMMYYYY]);
+        $project = Project::factory()->forOrganization($data->organization)->create();
+        TimeEntry::factory()->forOrganization($data->organization)->forProject($project)->forMember($data->member)
+            ->startWithDuration(Carbon::now()->subDay(), 3600)->create();
+        Passport::actingAs($data->user);
+
+        // Act
+        $response = $this->getJson(route('api.v1.time-entries.aggregate-export', [
+            $data->organization->getKey(),
+            'format' => ExportFormat::CSV,
+            'group' => TimeEntryAggregationType::Day,
+            'sub_group' => TimeEntryAggregationType::Project,
+            'history_group' => TimeEntryAggregationTypeInterval::Day,
+            'start' => Carbon::now()->subDays(7)->toIso8601ZuluString(),
+            'end' => Carbon::now()->toIso8601ZuluString(),
+        ]));
+
+        // Assert
+        $this->assertResponseCode($response, 200);
+        $disk = Storage::disk(config('filesystems.private'));
+        $files = $disk->files('exports');
+        $this->assertCount(1, $files);
+        $csv = $disk->get($files[0]);
+        $this->assertIsString($csv);
+        $this->assertStringContainsString('14/03/2024', $csv);
+        $this->assertStringNotContainsString('2024-03-14', $csv);
     }
 
     public function test_index_export_endpoint_with_client_ids_filter_returns_filtered_entries(): void

--- a/tests/Unit/Service/LocalizationServiceTest.php
+++ b/tests/Unit/Service/LocalizationServiceTest.php
@@ -326,15 +326,50 @@ class LocalizationServiceTest extends TestCaseWithDatabase
         $this->assertNull($formatted);
     }
 
-    public function test_format_time_group_key_returns_the_key_unchanged_for_non_day_group_types(): void
+    public function test_format_time_group_key_formats_a_week_key_as_the_range_it_covers(): void
+    {
+        // Arrange
+        $this->localizationService->setDateFormat(DateFormat::SlashSeparatedDDMMYYYY);
+
+        // Act
+        $formatted = $this->localizationService->formatTimeGroupKey('2026-07-27', TimeEntryAggregationType::Week);
+
+        // Assert
+        $this->assertSame('27/07/2026 - 02/08/2026', $formatted);
+    }
+
+    public function test_format_time_group_key_formats_a_week_range_from_the_weekday_of_its_own_key(): void
+    {
+        // Arrange
+        $this->localizationService->setDateFormat(DateFormat::SlashSeparatedDDMMYYYY);
+
+        // Act
+        $sundayStart = $this->localizationService->formatTimeGroupKey('2026-07-26', TimeEntryAggregationType::Week);
+        $mondayStart = $this->localizationService->formatTimeGroupKey('2026-07-20', TimeEntryAggregationType::Week);
+
+        // Assert
+        $this->assertSame('26/07/2026 - 01/08/2026', $sundayStart);
+        $this->assertSame('20/07/2026 - 26/07/2026', $mondayStart);
+    }
+
+    public function test_format_time_group_key_formats_a_week_range_spanning_new_year(): void
+    {
+        // Arrange
+        $this->localizationService->setDateFormat(DateFormat::SlashSeparatedDDMMYYYY);
+
+        // Act
+        $formatted = $this->localizationService->formatTimeGroupKey('2025-12-29', TimeEntryAggregationType::Week);
+
+        // Assert
+        $this->assertSame('29/12/2025 - 04/01/2026', $formatted);
+    }
+
+    public function test_format_time_group_key_does_not_change_month_year_and_entity_group_types(): void
     {
         // Arrange
         $this->localizationService->setDateFormat(DateFormat::SlashSeparatedDDMMYYYY);
 
         // Act & Assert
-        // Week/month/year are not offered as a grouping in the reporting UI and their keys have
-        // different shapes, so they are passed through rather than formatted as a date.
-        $this->assertSame('2001-02-03', $this->localizationService->formatTimeGroupKey('2001-02-03', TimeEntryAggregationType::Week));
         $this->assertSame('2001-02', $this->localizationService->formatTimeGroupKey('2001-02', TimeEntryAggregationType::Month));
         $this->assertSame('2001', $this->localizationService->formatTimeGroupKey('2001', TimeEntryAggregationType::Year));
         $this->assertSame('some-uuid', $this->localizationService->formatTimeGroupKey('some-uuid', TimeEntryAggregationType::Project));

--- a/tests/Unit/Service/LocalizationServiceTest.php
+++ b/tests/Unit/Service/LocalizationServiceTest.php
@@ -364,14 +364,27 @@ class LocalizationServiceTest extends TestCaseWithDatabase
         $this->assertSame('29/12/2025 - 04/01/2026', $formatted);
     }
 
-    public function test_format_time_group_key_does_not_change_month_year_and_entity_group_types(): void
+    public function test_format_time_group_key_formats_a_month_key_and_does_not_change_year_and_entity_group_types(): void
     {
         // Arrange
         $this->localizationService->setDateFormat(DateFormat::SlashSeparatedDDMMYYYY);
 
         // Act & Assert
-        $this->assertSame('2001-02', $this->localizationService->formatTimeGroupKey('2001-02', TimeEntryAggregationType::Month));
+        $this->assertSame('February 2001', $this->localizationService->formatTimeGroupKey('2001-02', TimeEntryAggregationType::Month));
         $this->assertSame('2001', $this->localizationService->formatTimeGroupKey('2001', TimeEntryAggregationType::Year));
         $this->assertSame('some-uuid', $this->localizationService->formatTimeGroupKey('some-uuid', TimeEntryAggregationType::Project));
+    }
+
+    public function test_format_time_group_key_formats_a_month_key_independently_of_the_current_day_of_month(): void
+    {
+        // Arrange
+        // Note: the current day of the month must not leak into the parsed month. The 31st does
+        // not exist in April, so a leaked day overflows the date into the following month.
+        $this->travelTo(Carbon::create(2026, 8, 31, 12, 0, 0, 'UTC'));
+
+        // Act & Assert
+        $this->assertSame('February 2001', $this->localizationService->formatTimeGroupKey('2001-02', TimeEntryAggregationType::Month));
+        $this->assertSame('April 2026', $this->localizationService->formatTimeGroupKey('2026-04', TimeEntryAggregationType::Month));
+        $this->assertSame('December 2026', $this->localizationService->formatTimeGroupKey('2026-12', TimeEntryAggregationType::Month));
     }
 }

--- a/tests/Unit/Service/LocalizationServiceTest.php
+++ b/tests/Unit/Service/LocalizationServiceTest.php
@@ -8,6 +8,7 @@ use App\Enums\CurrencyFormat;
 use App\Enums\DateFormat;
 use App\Enums\IntervalFormat;
 use App\Enums\NumberFormat;
+use App\Enums\TimeEntryAggregationType;
 use App\Enums\TimeFormat;
 use App\Service\LocalizationService;
 use Brick\Money\Currency;
@@ -302,5 +303,40 @@ class LocalizationServiceTest extends TestCaseWithDatabase
 
         // Assert
         $this->assertSame('14:09', $formatted);
+    }
+
+    public function test_format_time_group_key_formats_a_day_key_with_the_date_format(): void
+    {
+        // Arrange
+        $this->localizationService->setDateFormat(DateFormat::SlashSeparatedDDMMYYYY);
+
+        // Act
+        $formatted = $this->localizationService->formatTimeGroupKey('2001-02-03', TimeEntryAggregationType::Day);
+
+        // Assert
+        $this->assertSame('03/02/2001', $formatted);
+    }
+
+    public function test_format_time_group_key_returns_null_for_a_null_key(): void
+    {
+        // Act
+        $formatted = $this->localizationService->formatTimeGroupKey(null, TimeEntryAggregationType::Day);
+
+        // Assert
+        $this->assertNull($formatted);
+    }
+
+    public function test_format_time_group_key_returns_the_key_unchanged_for_non_day_group_types(): void
+    {
+        // Arrange
+        $this->localizationService->setDateFormat(DateFormat::SlashSeparatedDDMMYYYY);
+
+        // Act & Assert
+        // Week/month/year are not offered as a grouping in the reporting UI and their keys have
+        // different shapes, so they are passed through rather than formatted as a date.
+        $this->assertSame('2001-02-03', $this->localizationService->formatTimeGroupKey('2001-02-03', TimeEntryAggregationType::Week));
+        $this->assertSame('2001-02', $this->localizationService->formatTimeGroupKey('2001-02', TimeEntryAggregationType::Month));
+        $this->assertSame('2001', $this->localizationService->formatTimeGroupKey('2001', TimeEntryAggregationType::Year));
+        $this->assertSame('some-uuid', $this->localizationService->formatTimeGroupKey('some-uuid', TimeEntryAggregationType::Project));
     }
 }

--- a/tests/Unit/Service/TimeEntryAggregationServiceTest.php
+++ b/tests/Unit/Service/TimeEntryAggregationServiceTest.php
@@ -1302,4 +1302,111 @@ class TimeEntryAggregationServiceTest extends TestCaseWithDatabase
             ],
         ], $result);
     }
+
+    public function test_aggregate_time_entries_by_week_keys_each_group_by_the_first_day_of_the_week(): void
+    {
+        // Arrange
+        // 2026-07-20 is a Monday, 2026-07-26 is the Sunday of that week.
+        foreach (['2026-07-20', '2026-07-26', '2026-07-27'] as $day) {
+            TimeEntry::factory()->startWithDuration(Carbon::parse($day.' 09:00:00', 'UTC'), 10)->create();
+        }
+        $query = TimeEntry::query();
+
+        // Act
+        $result = $this->service->getAggregatedTimeEntries(
+            $query,
+            TimeEntryAggregationType::Week,
+            null,
+            'UTC',
+            Weekday::Monday,
+            false,
+            null,
+            null,
+            true,
+            null,
+            null
+        );
+
+        // Assert
+        $this->assertSame([
+            'seconds' => 30,
+            'cost' => 0,
+            'grouped_type' => 'week',
+            'grouped_data' => [
+                [
+                    'key' => '2026-07-20',
+                    'seconds' => 20,
+                    'cost' => 0,
+                    'grouped_type' => null,
+                    'grouped_data' => null,
+                ],
+                [
+                    'key' => '2026-07-27',
+                    'seconds' => 10,
+                    'cost' => 0,
+                    'grouped_type' => null,
+                    'grouped_data' => null,
+                ],
+            ],
+        ], $result);
+    }
+
+    public function test_aggregate_time_entries_by_week_aligns_the_group_key_to_the_organization_week_start(): void
+    {
+        // Arrange
+        // With a Sunday week start the Sunday entry belongs to the following week instead.
+        foreach (['2026-07-20', '2026-07-26', '2026-07-27'] as $day) {
+            TimeEntry::factory()->startWithDuration(Carbon::parse($day.' 09:00:00', 'UTC'), 10)->create();
+        }
+        $query = TimeEntry::query();
+
+        // Act
+        $result = $this->service->getAggregatedTimeEntries(
+            $query,
+            TimeEntryAggregationType::Week,
+            null,
+            'UTC',
+            Weekday::Sunday,
+            false,
+            null,
+            null,
+            true,
+            null,
+            null
+        );
+
+        // Assert
+        $this->assertSame(['2026-07-19', '2026-07-26'], array_column($result['grouped_data'], 'key'));
+        $this->assertSame([10, 20], array_column($result['grouped_data'], 'seconds'));
+    }
+
+    public function test_aggregate_time_entries_by_week_keys_a_week_spanning_new_year_by_its_start_in_the_earlier_year(): void
+    {
+        // Arrange
+        // Note: 2025-12-29 is the Monday of the week containing 1 January 2026
+        foreach (['2025-12-29', '2025-12-31', '2026-01-01', '2026-01-05'] as $day) {
+            TimeEntry::factory()->startWithDuration(Carbon::parse($day.' 09:00:00', 'UTC'), 10)->create();
+        }
+        $query = TimeEntry::query();
+
+        // Act
+        $result = $this->service->getAggregatedTimeEntries(
+            $query,
+            TimeEntryAggregationType::Week,
+            null,
+            'UTC',
+            Weekday::Monday,
+            false,
+            null,
+            null,
+            true,
+            null,
+            null
+        );
+
+        // Assert
+        $this->assertSame(['2025-12-29', '2026-01-05'], array_column($result['grouped_data'], 'key'));
+        // Three of the four entries fall in the week that straddles new year.
+        $this->assertSame([30, 10], array_column($result['grouped_data'], 'seconds'));
+    }
 }


### PR DESCRIPTION
## What does this PR do?

Adds `Date` and `Week` options to the report grouping dropdown. The menu is starting to get a bit long, but I think it's still reasonable:
<img width="338" height="396" alt="Screenshot 2026-08-16 at 4 23 39 pm" src="https://github.com/user-attachments/assets/f2f79573-118b-43e9-a2ea-8bcc314343b2" />

I've updated the frontend, exported reports and shared reports. Screenshots below.

- Fixes #370
- Leverages discussion in #1165

## Checklist (DO NOT REMOVE)

- [x] I read the [contributing guide](https://github.com/solidtime-io/solidtime/blob/main/CONTRIBUTING.md)
- [x] I signed the [Contributor License Agreement](https://cla-assistant.io/solidtime-io/solidtime).
- [x] I commented my code, particularly in hard-to-understand areas
---
### Report grouped by date:
<img width="1003" height="974" alt="Screenshot 2026-08-16 at 4 24 31 pm" src="https://github.com/user-attachments/assets/0de59d1b-034a-4eb0-9984-bd5b7c8fbdb3" />

### Report grouped by week:
<img width="735" height="957" alt="Screenshot 2026-08-19 at 4 47 13 pm" src="https://github.com/user-attachments/assets/12142d63-4077-43fc-ab82-c21f7cc5f906" />



<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/solidtime-io/codesmith/solidtime/pr/1210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789455218&installation_model_id=431217&pr_number=1210&repository=solidtime-io%2Fsolidtime&return_to=https%3A%2F%2Fgithub.com%2Fsolidtime-io%2Fsolidtime%2Fpull%2F1210&signature=a30a382f9e25665f9629b93cf4c2051a2ac02103b37d9504fc55ebbd069f3851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->