### PR TITLE
Normalize running dashboard timestamps to UTC

### DIFF
--- a/app/Service/DashboardService.php
+++ b/app/Service/DashboardService.php
@@ -152,7 +152,7 @@ class DashboardService
         $possibleDays = $this->lastDays($days, $timezone);
 
         $query = TimeEntry::query()
-            ->select(DB::raw('DATE('.$dateWithTimeZone.') as date, round(sum(extract(epoch from (coalesce("end", now()) - start)))) as aggregate'))
+            ->select(DB::raw('DATE('.$dateWithTimeZone.') as date, round(sum(extract(epoch from (coalesce("end", now() AT TIME ZONE \'UTC\') - start)))) as aggregate'))
             ->where('user_id', '=', $user->getKey())
             ->where('organization_id', '=', $organization->getKey())
             ->workTime()
@@ -194,7 +194,7 @@ class DashboardService
         $possibleDays = $this->daysOfThisWeek($timezone, $user->week_start);
 
         $query = TimeEntry::query()
-            ->select(DB::raw('DATE('.$dateWithTimeZone.') as date, round(sum(extract(epoch from (coalesce("end", now()) - start)))) as aggregate'))
+            ->select(DB::raw('DATE('.$dateWithTimeZone.') as date, round(sum(extract(epoch from (coalesce("end", now() AT TIME ZONE \'UTC\') - start)))) as aggregate'))
             ->where('user_id', '=', $user->getKey())
             ->where('organization_id', '=', $organization->getKey())
             ->workTime()
@@ -223,7 +223,7 @@ class DashboardService
         $possibleDays = $this->daysOfThisWeek($timezone, $user->week_start);
 
         $query = TimeEntry::query()
-            ->select(DB::raw('round(sum(extract(epoch from (coalesce("end", now()) - start)))) as aggregate'))
+            ->select(DB::raw('round(sum(extract(epoch from (coalesce("end", now() AT TIME ZONE \'UTC\') - start)))) as aggregate'))
             ->where('user_id', '=', $user->getKey())
             ->where('organization_id', '=', $organization->getKey())
             ->workTime();
@@ -241,7 +241,7 @@ class DashboardService
         $possibleDays = $this->daysOfThisWeek($timezone, $user->week_start);
 
         $query = TimeEntry::query()
-            ->select(DB::raw('round(sum(extract(epoch from (coalesce("end", now()) - start)))) as aggregate'))
+            ->select(DB::raw('round(sum(extract(epoch from (coalesce("end", now() AT TIME ZONE \'UTC\') - start)))) as aggregate'))
             ->where('billable', '=', true)
             ->where('user_id', '=', $user->getKey())
             ->where('organization_id', '=', $organization->getKey());
@@ -265,7 +265,7 @@ class DashboardService
             ->select(DB::raw('
                round(
                     sum(
-                        extract(epoch from (coalesce("end", now()) - start)) * (billable_rate::float/60/60)
+                        extract(epoch from (coalesce("end", now() AT TIME ZONE \'UTC\') - start)) * (billable_rate::float/60/60)
                     )
                ) as aggregate'))
             ->where('billable', '=', true)
@@ -291,7 +291,7 @@ class DashboardService
         $timezone = $this->timezoneService->getTimezoneFromUser($user);
 
         $query = TimeEntry::query()
-            ->select(DB::raw('project_id, round(sum(extract(epoch from (coalesce("end", now()) - start)))) as aggregate'))
+            ->select(DB::raw('project_id, round(sum(extract(epoch from (coalesce("end", now() AT TIME ZONE \'UTC\') - start)))) as aggregate'))
             ->where('user_id', '=', $user->getKey())
             ->where('organization_id', '=', $organization->getKey())
             ->workTime()

--- a/tests/Unit/Service/DashboardServiceTest.php
+++ b/tests/Unit/Service/DashboardServiceTest.php
@@ -15,6 +15,7 @@ use App\Models\User;
 use App\Service\DashboardService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Tests\TestCase;
 
@@ -137,6 +138,29 @@ class DashboardServiceTest extends TestCase
                 'duration' => 0,
             ],
         ], $result);
+    }
+
+    public function test_weekly_history_calculates_running_entry_duration_without_timezone_coercion(): void
+    {
+        DB::statement("SET LOCAL TIME ZONE INTERVAL '-01:00' HOUR TO MINUTE");
+        $now = Carbon::parse((string) DB::scalar("SELECT now() AT TIME ZONE 'UTC'"), 'UTC');
+        $this->travelTo($now);
+        $start = $now->copy()->subHour();
+
+        $organization = Organization::factory()->create();
+        $user = User::factory()->create([
+            'timezone' => 'UTC',
+            'week_start' => Weekday::from(strtolower($start->format('l'))),
+        ]);
+        $member = Member::factory()->forUser($user)->forOrganization($organization)->create();
+        TimeEntry::factory()->forMember($member)->forOrganization($organization)->active()->create([
+            'start' => $start,
+        ]);
+
+        $result = $this->dashboardService->getWeeklyHistory($user, $organization);
+        $entryDay = collect($result)->firstWhere('date', $start->toDateString());
+
+        $this->assertEqualsWithDelta(3600, $entryDay['duration'], 1);
     }
 
     public function test_total_weekly_time_returns_correct_value(): void


### PR DESCRIPTION
## What does this PR do?

Convert PostgreSQL’s current time to a UTC `timestamp without time zone` before using it as the end of running time entries. This matches the type and UTC basis of the stored start and end values, avoiding implicit timezone coercion and calculating running durations consistently with completed entries.

Adds regression coverage for calculating running durations without timezone coercion.

- Fixes #1225

## Testing

- `php artisan test tests/Unit/Service/DashboardServiceTest.php`

## Checklist (DO NOT REMOVE)

- [x] I read the [contributing guide](https://github.com/solidtime-io/solidtime/blob/main/CONTRIBUTING.md)
- [x] I signed the [Contributor License Agreement](https://cla-assistant.io/solidtime-io/solidtime).
- [x] I commented my code, particularly in hard-to-understand areas
