### PR TITLE
show running timer in browser tab

### DIFF
--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -53,8 +53,11 @@ import { Button } from '@/packages/ui/src/Buttons';
 import { openFeedback } from '@/utils/feedback';
 import { CommandPaletteProvider } from '@/Components/CommandPalette';
 import { useCommandPalette } from '@/utils/useCommandPalette';
+import { useTabTimerIndicator } from '@/utils/useTabTimerIndicator';
 
 const { openPalette } = useCommandPalette();
+
+useTabTimerIndicator();
 
 defineProps({
     title: String,

--- a/resources/js/utils/useTabTimerIndicator.test.ts
+++ b/resources/js/utils/useTabTimerIndicator.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { buildTabTitle, resolveTabTimerIndicator } from './useTabTimerIndicator';
+
+describe('resolveTabTimerIndicator', () => {
+    it('is idle when no timer is running', () => {
+        expect(resolveTabTimerIndicator(false, false)).toBe('idle');
+        expect(resolveTabTimerIndicator(false, true)).toBe('idle');
+    });
+
+    it('is work when a non-break timer is running', () => {
+        expect(resolveTabTimerIndicator(true, false)).toBe('work');
+    });
+
+    it('is break when a break timer is running', () => {
+        expect(resolveTabTimerIndicator(true, true)).toBe('break');
+    });
+});
+
+describe('buildTabTitle', () => {
+    it('keeps the base title while idle', () => {
+        expect(
+            buildTabTitle(
+                { indicator: 'idle', durationSeconds: 0, description: null },
+                'Dashboard - solidtime'
+            )
+        ).toBe('Dashboard - solidtime');
+    });
+
+    it('shows duration and description while working', () => {
+        expect(
+            buildTabTitle(
+                { indicator: 'work', durationSeconds: 5025, description: 'Fixing login bug' },
+                'Dashboard - solidtime'
+            )
+        ).toBe('01:23:45 · Fixing login bug');
+    });
+
+    it('falls back to "No description" when the entry has none', () => {
+        expect(
+            buildTabTitle(
+                { indicator: 'work', durationSeconds: 5, description: '   ' },
+                'Dashboard - solidtime'
+            )
+        ).toBe('00:00:05 · No description');
+    });
+
+    it('labels break entries', () => {
+        expect(
+            buildTabTitle(
+                { indicator: 'break', durationSeconds: 312, description: 'ignored' },
+                'Dashboard - solidtime'
+            )
+        ).toBe('☕ 00:05:12 · Break');
+    });
+
+    it('never renders a negative duration', () => {
+        expect(
+            buildTabTitle(
+                { indicator: 'work', durationSeconds: -3, description: 'Task' },
+                'Dashboard - solidtime'
+            )
+        ).toBe('00:00:00 · Task');
+    });
+});

--- a/resources/js/utils/useTabTimerIndicator.ts
+++ b/resources/js/utils/useTabTimerIndicator.ts
@@ -1,0 +1,181 @@
+import { computed, onScopeDispose, ref, watch } from 'vue';
+import { storeToRefs } from 'pinia';
+import { router } from '@inertiajs/vue3';
+import dayjs from 'dayjs';
+import { formatDuration } from '@/packages/ui/src/utils/time';
+import { useCurrentTimeEntryStore } from '@/utils/useCurrentTimeEntry';
+
+/**
+ * Keeps the browser tab in sync with the running timer so you can tell at a
+ * glance whether solidtime is still tracking, even when the tab is in the
+ * background:
+ *
+ *  - the tab title shows the running duration and the entry description
+ *  - the favicon gets a colored dot (green while working, amber during a break)
+ *
+ * When no timer is running the original title and favicons are left untouched.
+ */
+
+export type TabTimerIndicator = 'idle' | 'work' | 'break';
+
+type TabTimerState = {
+    indicator: TabTimerIndicator;
+    durationSeconds: number;
+    description: string | null | undefined;
+};
+
+const DOT_COLOR: Record<Exclude<TabTimerIndicator, 'idle'>, string> = {
+    work: '#22c55e',
+    break: '#f59e0b',
+};
+
+const BASE_FAVICON_URL = '/favicons/favicon-32x32.png';
+const DYNAMIC_FAVICON_ATTR = 'data-dynamic-favicon';
+
+export function resolveTabTimerIndicator(isActive: boolean, isOnBreak: boolean): TabTimerIndicator {
+    if (!isActive) {
+        return 'idle';
+    }
+    return isOnBreak ? 'break' : 'work';
+}
+
+export function buildTabTitle(state: TabTimerState, baseTitle: string): string {
+    if (state.indicator === 'idle') {
+        return baseTitle;
+    }
+    const time = formatDuration(Math.max(0, Math.floor(state.durationSeconds)));
+    if (state.indicator === 'break') {
+        return `☕ ${time} · Break`;
+    }
+    const description = state.description?.trim();
+    return `${time} · ${description ? description : 'No description'}`;
+}
+
+let stashedFavicons: HTMLLinkElement[] = [];
+
+function applyDynamicFavicon(dataUri: string) {
+    const existing = document.head.querySelector<HTMLLinkElement>(`link[${DYNAMIC_FAVICON_ATTR}]`);
+    if (existing) {
+        existing.href = dataUri;
+        return;
+    }
+    stashedFavicons = Array.from(
+        document.head.querySelectorAll<HTMLLinkElement>('link[rel~="icon"]')
+    );
+    stashedFavicons.forEach((link) => link.remove());
+
+    const link = document.createElement('link');
+    link.rel = 'icon';
+    link.type = 'image/png';
+    link.setAttribute(DYNAMIC_FAVICON_ATTR, 'true');
+    link.href = dataUri;
+    document.head.appendChild(link);
+}
+
+function restoreFavicon() {
+    const dynamic = document.head.querySelectorAll(`link[${DYNAMIC_FAVICON_ATTR}]`);
+    if (dynamic.length === 0 && stashedFavicons.length === 0) {
+        return;
+    }
+    dynamic.forEach((link) => link.remove());
+    stashedFavicons.forEach((link) => document.head.appendChild(link));
+    stashedFavicons = [];
+}
+
+async function renderFaviconWithDot(color: string): Promise<string | null> {
+    const size = 32;
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+        return null;
+    }
+
+    await new Promise<void>((resolve) => {
+        const image = new Image();
+        image.onload = () => {
+            ctx.drawImage(image, 0, 0, size, size);
+            resolve();
+        };
+        image.onerror = () => resolve();
+        image.src = BASE_FAVICON_URL;
+    });
+
+    const radius = 7;
+    const center = size - radius - 1;
+
+    ctx.beginPath();
+    ctx.arc(center, center, radius + 2, 0, Math.PI * 2);
+    ctx.fillStyle = '#ffffff';
+    ctx.fill();
+
+    ctx.beginPath();
+    ctx.arc(center, center, radius, 0, Math.PI * 2);
+    ctx.fillStyle = color;
+    ctx.fill();
+
+    return canvas.toDataURL('image/png');
+}
+
+export function useTabTimerIndicator() {
+    const store = useCurrentTimeEntryStore();
+    const { currentTimeEntry, now, isActive, isOnBreak } = storeToRefs(store);
+
+    const baseTitle = ref(document.title);
+
+    const indicator = computed(() => resolveTabTimerIndicator(isActive.value, isOnBreak.value));
+
+    const durationSeconds = computed(() => {
+        if (!now.value || !currentTimeEntry.value.start) {
+            return 0;
+        }
+        return now.value.diff(dayjs(currentTimeEntry.value.start), 's');
+    });
+
+    function applyTitle() {
+        document.title = buildTabTitle(
+            {
+                indicator: indicator.value,
+                durationSeconds: durationSeconds.value,
+                description: currentTimeEntry.value.description,
+            },
+            baseTitle.value
+        );
+    }
+
+    // Inertia rewrites document.title on every page visit. Re-capture it while
+    // idle, and re-apply the timer title right after navigation otherwise.
+    const stopNavigateListener = router.on('navigate', () => {
+        window.requestAnimationFrame(() => {
+            if (indicator.value === 'idle') {
+                baseTitle.value = document.title;
+            } else {
+                applyTitle();
+            }
+        });
+    });
+
+    watch([indicator, durationSeconds], applyTitle, { immediate: true });
+
+    watch(
+        indicator,
+        async (value) => {
+            if (value === 'idle') {
+                restoreFavicon();
+                return;
+            }
+            const dataUri = await renderFaviconWithDot(DOT_COLOR[value]);
+            if (dataUri) {
+                applyDynamicFavicon(dataUri);
+            }
+        },
+        { immediate: true }
+    );
+
+    onScopeDispose(() => {
+        stopNavigateListener();
+        restoreFavicon();
+        document.title = baseTitle.value;
+    });
+}


### PR DESCRIPTION
## Summary

Mirrors the running-timer state into the browser tab so you can tell at a
glance whether solidtime is still tracking while the tab is in the background:

- **Tab title** while a timer runs: `HH:MM:SS · <description>`
  (`☕ HH:MM:SS · Break` for break entries). The Inertia page title is left
  untouched when nothing is running.
- **Favicon** gets a colored dot drawn onto the existing icon via canvas:
  green while working, amber during a break. Original favicons are restored
  when the timer stops.

Closes #<DISCUSSION_OR_ISSUE_NUMBER>

## Screenshots

| idle | work | break |
|---|---|---|
| _(unchanged)_ | green dot + `00:12:34 · Task` | amber dot + `☕ 00:03:10 · Break` |

<!-- attach the three tab screenshots here -->

## Reasoning / decisions

- **New composable, one call site.** `useTabTimerIndicator()` is called once in
  `AppLayout.vue` (the only authenticated layout, and where
  `CurrentSidebarTimer` already lives). It reads the existing
  `useCurrentTimeEntryStore` refs (`isActive`, `isOnBreak`, `currentTimeEntry`,
  `now`) rather than adding any new state.
- **Title updates every second, favicon only on transitions.** The per-second
  `now` tick drives the title; the favicon is re-rendered only when the
  indicator changes between `idle` / `work` / `break`, to avoid pointless
  canvas work each second.
- **Inertia navigation.** Inertia rewrites `document.title` on every visit, so
  a `router.on('navigate')` handler re-captures the base title while idle and
  re-applies the timer title otherwise.
- **No new assets.** The favicon dot is drawn on top of the current
  `favicon-32x32.png` on a canvas and set as a data URI, so there are no new
  binary files and nothing to keep in sync. If the canvas is unavailable the
  favicon is simply left unchanged.
- **Cleanup.** `onScopeDispose` restores the original title and favicon links.
- Always on, no setting — matches the Toggl behavior this mirrors. Easy to put
  behind a preference later if desired.

## Tests

- `resources/js/utils/useTabTimerIndicator.test.ts` — unit tests for the pure
  helpers `buildTabTitle()` (idle / work / break / missing description /
  negative duration) and `resolveTabTimerIndicator()`.
- `npm run test:unit` — full suite green (197 passing).
- `npm run lint` — clean.
- `npm run type-check` — clean.
- Manual (on a self-hosted build): start/stop work and break timers, switch
  organizations, navigate between pages — title and favicon update within a
  second and reset correctly when the timer stops.

## Files

- `resources/js/utils/useTabTimerIndicator.ts` (new)
- `resources/js/utils/useTabTimerIndicator.test.ts` (new)
- `resources/js/Layouts/AppLayout.vue` (+3 lines)